### PR TITLE
Add GoReleaser to ci pipeline and add config file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install Wails dependencies
+        run: sudo apt-get install -qq -y libwebkit2gtk-4.0-dev libgtk-3-dev npm pkg-config
+    
+      - name: Set up Wails
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ go.work.sum
 .env
 
 **/build/**
+
+dist/**

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,88 @@
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+
+# Test with `goreleaser --snapshot --clean`
+# To release, create a tag and push it to Github: `git tag -a v0.1.0 -m "First release" && git push origin v0.1.0`. GoReleaser enforces semantic versioning and will error on non-compliant tags.
+# For it to work, you need to have the `GITHUB_TOKEN` environment variable set export GITHUB_TOKEN="YOUR_GH_TOKEN". The minimum permissions the GITHUB_TOKEN should have to run this are write:packages
+
+# Now you can run GoReleaser at the root of your repository: `goreleaser release`
+# For dry run, see https://goreleaser.com/quick-start/#dry-run
+
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  # The app build is invoked via wails and binary copied manually to the expected output folder
+  - id: "openem-ingestor-app"
+    hooks:
+        pre:
+        - cmd: mkdir {{dir .Path}}
+        post:
+        - dir: cmd/openem-ingestor-app
+          cmd: wails build -platform {{ .Os }} -clean -ldflags "-s -w  -X 'main.version={{.Version}}'" -trimpath -o {{base .Path}}
+        - dir: cmd/openem-ingestor-app
+          cmd: cp build/bin/{{base .Path}} {{dir .Path}}/
+    env:
+      - CGO_ENABLED=0
+    dir: ./cmd/openem-ingestor-app
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+    main: .
+    binary: openem-ingestor-app
+    gobinary: echo 
+
+
+  # TODO: add service build
+  # - id: "openem-ingestor-service"
+  #   flags:
+  #     - -trimpath
+  #   ldflags:
+  #     - "-s -w  -X 'main.version={{.Version}}'"
+  #   env:
+  #     - CGO_ENABLED=0
+  #   dir: ./cmd/openem-ingestor-service
+  #   goos:
+  #     - linux
+  #   goarch:
+  #     - amd64
+  #   main: .
+  #   binary: openem-ingestor-service
+
+archives:
+  - format: tar.gz
+    wrap_in_directory: true
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+    - configs/*.yaml
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  prerelease: auto

--- a/cmd/openem-ingestor-app/frontend/.gitignore
+++ b/cmd/openem-ingestor-app/frontend/.gitignore
@@ -1,1 +1,2 @@
 node_modules/**
+dist/**

--- a/cmd/openem-ingestor-app/main.go
+++ b/cmd/openem-ingestor-app/main.go
@@ -16,7 +16,12 @@ import (
 //go:embed all:frontend/dist
 var assets embed.FS
 
+// String can be overwritten by using linker flags: -ldflags "-X main.version=VERSION"
+var version string = "DEVELOPMENT_VERSION"
+
 func main() {
+
+	log.Printf("Version %s", version)
 
 	if err := core.ReadConfig(); err != nil {
 		log.Print(fmt.Errorf("failed to read config file: %w", err))

--- a/cmd/openem-ingestor-service/main.go
+++ b/cmd/openem-ingestor-service/main.go
@@ -9,7 +9,12 @@ import (
 	"github.com/spf13/viper"
 )
 
+// String can be overwritten by using linker flags: -ldflags "-X main.version=VERSION"
+var version string = "DEVELOPMENT_VERSION"
+
 func main() {
+	log.Printf("Version %s", version)
+
 	if err := core.ReadConfig(); err != nil {
 		panic(fmt.Errorf("Failed to read config file: %w", err))
 	}


### PR DESCRIPTION
Adds goreleaser https://goreleaser.com to create releases of the app. Every manually created tag creates a new release. In the archives, there is the binary and the example config.yaml. Didn't add a readme yet.

Example:
https://github.com/SwissOpenEM/Ingestor/releases/tag/v0.0.5

(examples and tests will be deleted)