### PR TITLE
Ingest from collection location

### DIFF
--- a/internal/core/ingestdataset.go
+++ b/internal/core/ingestdataset.go
@@ -203,7 +203,9 @@ func IngestDataset(
 	case task.TransferS3:
 		_, err = UploadS3(task_context, datasetId, datasetFolder, ingestionTask.DatasetFolder.Id, config.Transfer.S3, notifier)
 	case task.TransferGlobus:
-		err = GlobusTransfer(config.Transfer.Globus, ingestionTask, task_context, ingestionTask.DatasetFolder.Id, datasetFolder, fullFileArray, notifier)
+		// globus doesn't work with absolute folders, this library uses sourcePrefix to adapt the path to the globus' own path from a relative path
+		relativeDatasetFolder := strings.TrimPrefix(datasetFolder, config.WebServer.CollectionLocation)
+		err = GlobusTransfer(config.Transfer.Globus, ingestionTask, task_context, ingestionTask.DatasetFolder.Id, relativeDatasetFolder, fullFileArray, notifier)
 	_:
 	}
 

--- a/internal/core/taskqueue.go
+++ b/internal/core/taskqueue.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -67,7 +69,8 @@ func (w *TaskQueue) CreateTaskFromMetadata(id uuid.UUID, metadataMap map[string]
 	}
 	switch v := metadataMap["sourceFolder"].(type) {
 	case string:
-		task.DatasetFolder.FolderPath = v
+		// the collection location has to be added to get the absolute path of the dataset
+		task.DatasetFolder.FolderPath = path.Join(w.Config.WebServer.CollectionLocation, filepath.FromSlash(v))
 	default:
 		return errors.New("sourceFolder in metadata isn't a string")
 	}

--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"slices"
 
 	"github.com/google/uuid"
@@ -20,11 +19,11 @@ func (i *IngestorWebServerImplemenation) DatasetControllerIngestDataset(ctx cont
 	}
 
 	// add collection location
-	dsPath, ok := metadata["sourceFolder"].(string)
+	/*dsPath, ok := metadata["sourceFolder"].(string)
 	if !ok {
 		return DatasetControllerIngestDataset400TextResponse("datasetFolder is not a string"), nil
 	}
-	metadata["sourceFolder"] = path.Join(i.pathConfig.CollectionLocation, dsPath)
+	metadata["sourceFolder"] = path.Join(i.pathConfig.CollectionLocation, dsPath)*/
 
 	// create and start task
 	id := uuid.New()


### PR DESCRIPTION
This fixes a bug where the datasetFolder was assumed to be absolute, and the collection location wasn't applied correctly. 