### PR TITLE
Feature/csrf safe cookie auth

### DIFF
--- a/configs/openem-ingestor-config.yaml
+++ b/configs/openem-ingestor-config.yaml
@@ -43,7 +43,9 @@ WebServer:
   Auth:
     Disable: false
     SessionDuration: 28800
-    FrontendUrl: "http://localhost"
+    Frontend:
+      Origin: "http://localhost"
+      RedirectPath: "/ingestor"
     OAuth2:
       ClientID: "ingestor"
       RedirectURL: "http://localhost:8888/callback"

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -56,7 +56,10 @@ func createExpectedValidConfig(transferConfig task.TransferConfig) Config {
 	expected_ws := wsconfig.WebServerConfig{
 		AuthConf: wsconfig.AuthConf{
 			SessionDuration: 28800,
-			FrontendUrl:     "http://scicat.localhost/ingest",
+			FrontendConf: wsconfig.FrontendConf{
+				Origin:       "http://scicat.localhost",
+				RedirectPath: "/ingestor",
+			},
 			OAuth2Conf: wsconfig.OAuth2Conf{
 				ClientID:    "ingestor",
 				RedirectURL: "http://localhost:8888/callback",

--- a/internal/webserver/api.go
+++ b/internal/webserver/api.go
@@ -19,19 +19,20 @@ import (
 var _ StrictServerInterface = (*IngestorWebServerImplemenation)(nil)
 
 type IngestorWebServerImplemenation struct {
-	version          string
-	taskQueue        *core.TaskQueue
-	metp             *metadatatasks.MetadataExtractionTaskPool
-	extractorHandler *metadataextractor.ExtractorHandler
-	oauth2Config     *oauth2.Config
-	oidcProvider     *oidc.Provider
-	oidcVerifier     *oidc.IDTokenVerifier
-	jwtKeyfunc       jwt.Keyfunc
-	jwtSignMethods   []string
-	sessionDuration  uint
-	scopeToRoleMap   map[string]string
-	pathConfig       wsconfig.PathsConf
-	frontendUrl      string
+	version              string
+	taskQueue            *core.TaskQueue
+	metp                 *metadatatasks.MetadataExtractionTaskPool
+	extractorHandler     *metadataextractor.ExtractorHandler
+	oauth2Config         *oauth2.Config
+	oidcProvider         *oidc.Provider
+	oidcVerifier         *oidc.IDTokenVerifier
+	jwtKeyfunc           jwt.Keyfunc
+	jwtSignMethods       []string
+	sessionDuration      uint
+	scopeToRoleMap       map[string]string
+	pathConfig           wsconfig.PathsConf
+	frontendOrigin       string
+	frontendRedirectPath string
 }
 
 func NewIngestorWebServer(version string, tq *core.TaskQueue, eh *metadataextractor.ExtractorHandler, ws wsconfig.WebServerConfig) (*IngestorWebServerImplemenation, error) {
@@ -77,18 +78,19 @@ func NewIngestorWebServer(version string, tq *core.TaskQueue, eh *metadataextrac
 	metp := metadatatasks.NewTaskPool(ws.QueueSize, ws.NoWorkers, eh)
 
 	return &IngestorWebServerImplemenation{
-		version:          version,
-		taskQueue:        tq,
-		extractorHandler: eh,
-		oauth2Config:     &oauthConf,
-		oidcProvider:     oidcProvider,
-		oidcVerifier:     oidcVerifier,
-		jwtKeyfunc:       keyfunc,
-		jwtSignMethods:   signMethods,
-		scopeToRoleMap:   scopeToRoleMap,
-		sessionDuration:  ws.SessionDuration,
-		pathConfig:       ws.PathsConf,
-		metp:             metp,
-		frontendUrl:      ws.FrontendUrl,
+		version:              version,
+		taskQueue:            tq,
+		extractorHandler:     eh,
+		oauth2Config:         &oauthConf,
+		oidcProvider:         oidcProvider,
+		oidcVerifier:         oidcVerifier,
+		jwtKeyfunc:           keyfunc,
+		jwtSignMethods:       signMethods,
+		scopeToRoleMap:       scopeToRoleMap,
+		sessionDuration:      ws.SessionDuration,
+		pathConfig:           ws.PathsConf,
+		metp:                 metp,
+		frontendOrigin:       ws.FrontendConf.Origin,
+		frontendRedirectPath: ws.FrontendConf.RedirectPath,
 	}, nil
 }

--- a/internal/webserver/auth.go
+++ b/internal/webserver/auth.go
@@ -155,10 +155,6 @@ func (i *IngestorWebServerImplemenation) GetCallback(ctx context.Context, reques
 	}
 
 	// set user session cookie
-	userSession.Options(sessions.Options{
-		HttpOnly: true,
-		MaxAge:   int(i.sessionDuration),
-	})
 	userSession.Set("expires_at", time.Now().Add(time.Second*time.Duration(i.sessionDuration)).Format(time.RFC3339Nano))
 	userSession.Set("email", userInfo.Email)
 	userSession.Set("profile", userInfo.Profile)
@@ -178,7 +174,7 @@ func (i *IngestorWebServerImplemenation) GetCallback(ctx context.Context, reques
 	// reply
 	return GetCallback302Response{
 		Headers: GetCallback302ResponseHeaders{
-			Location: i.frontendUrl,
+			Location: i.frontendOrigin + i.frontendRedirectPath,
 		},
 	}, nil
 }
@@ -202,6 +198,6 @@ func (i *IngestorWebServerImplemenation) GetLogout(ctx context.Context, request 
 	}
 
 	return GetLogout302Response{GetLogout302ResponseHeaders{
-		Location: i.frontendUrl,
+		Location: i.frontendOrigin + i.frontendRedirectPath,
 	}}, nil
 }

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -41,9 +41,10 @@ func NewIngesterServer(ingestor *IngestorWebServerImplemenation, port int) *http
 	r := gin.Default()
 
 	r.Use(cors.New(cors.Config{
-		AllowAllOrigins: true,
-		AllowMethods:    []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowHeaders:    []string{"Origin", "Content-Type", "Accept"},
+		AllowOrigins:     []string{ingestor.frontendOrigin},
+		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Accept"},
+		AllowCredentials: true,
 	}))
 
 	// The route here needs to match the embedded file.
@@ -67,6 +68,7 @@ func NewIngesterServer(ingestor *IngestorWebServerImplemenation, port int) *http
 	store := cookie.NewStore(authKey, encKey)
 	store.Options(sessions.Options{
 		HttpOnly: true,
+		SameSite: http.SameSiteNoneMode,
 	})
 
 	// register types to be stored in cookies

--- a/internal/webserver/wsconfig/config.go
+++ b/internal/webserver/wsconfig/config.go
@@ -35,11 +35,16 @@ type RBACConf struct {
 	ViewTasksRole         string `validate:"required"`
 }
 
+type FrontendConf struct {
+	Origin       string `validate:"required"`
+	RedirectPath string
+}
+
 // full authentication config
 type AuthConf struct {
-	Disable         bool   `bool:"Disable"`
-	SessionDuration uint   // duration of a user session before it expires (by default never)
-	FrontendUrl     string `validate:"required_if=Disable false,omitempty"` // used for redirecting the user back to the frontend after login
+	Disable         bool `bool:"Disable"`
+	SessionDuration uint // duration of a user session before it expires (by default never)
+	FrontendConf    `mapstructure:"Frontend" validate:"required_if=Disable false,omitempty"`
 	OAuth2Conf      `mapstructure:"OAuth2" validate:"required_if=Disable false,omitempty"`
 	OIDCConf        `mapstructure:"OIDC" validate:"required_if=Disable false,omitempty"`
 	JWTConf         `mapstructure:"JWT" validate:"required_if=Disable false,omitempty"`

--- a/test/testdata/valid_config_globus.yaml
+++ b/test/testdata/valid_config_globus.yaml
@@ -59,7 +59,9 @@ WebServer:
   Auth:
     Disable: false
     SessionDuration: 28800
-    FrontendUrl: "http://scicat.localhost/ingest"
+    Frontend: 
+      Origin: "http://scicat.localhost"
+      RedirectPath: "/ingestor"
     OAuth2:
       ClientID: "ingestor"
       RedirectURL: "http://localhost:8888/callback"

--- a/test/testdata/valid_config_s3.yaml
+++ b/test/testdata/valid_config_s3.yaml
@@ -56,7 +56,9 @@ WebServer:
   Auth:
     Disable: false
     SessionDuration: 28800
-    FrontendUrl: "http://scicat.localhost/ingest"
+    Frontend: 
+      Origin: "http://scicat.localhost"
+      RedirectPath: "/ingestor"
     OAuth2:
       ClientID: "ingestor"
       RedirectURL: "http://localhost:8888/callback"


### PR DESCRIPTION
This PR makes changes that enable a CSRF-safe way of handling HttpOnly cookies for auth from cross-origin sites by having a pre-configured list of approved origins.