### PR TITLE
'GET /metadata' - use params instead of request body

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -317,12 +317,19 @@ paths:
         Starts a metadata extraction task on the ingestor side, with live updates about the progress using Server Side Events (SSE).
         It will close the connection with the final message containing the metadata json.
       operationId: extractMetadata
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/GetMetadataRequest"
+      parameters:
+        - name: filePath
+          in: query
+          required: true
+          schema:
+            type: string
+            description: The file path of the selected data record.
+        - name: methodName
+          in: query
+          required: true
+          schema:
+            type: string
+            description: The selected methodName for data extraction.
       responses:
         '200':
           description: |
@@ -507,18 +514,6 @@ components:
         - name
         - schema
       description: a method item describes the method's name and schema
-    GetMetadataRequest:
-      type: object
-      properties:
-        filePath:
-          type: string
-          description: The file path of the selected data record.
-        methodName:
-          type: string
-          description: The selected methodName for data extraction.
-      required:
-        - filePath
-        - methodName
     GetDatasetResponse:
       type: object
       properties:

--- a/internal/webserver/metadata.go
+++ b/internal/webserver/metadata.go
@@ -27,7 +27,7 @@ func (r ResponseWriter) VisitExtractMetadataResponse(writer http.ResponseWriter)
 	g.Writer.Header().Add("Connection", "keep-alive")
 
 	// append collection path to input and generate extractor output filepath
-	fullPath := path.Join(r.collectionLocation, r.req.Body.FilePath)
+	fullPath := path.Join(r.collectionLocation, r.req.Params.FilePath)
 
 	// extract metadata
 	cancelCtx, cancel := context.WithCancel(r.ctx)
@@ -46,7 +46,7 @@ func (r ResponseWriter) VisitExtractMetadataResponse(writer http.ResponseWriter)
 				}
 			}
 			var err error
-			progress, err = r.metp.NewTask(cancelCtx, fullPath, r.req.Body.MethodName)
+			progress, err = r.metp.NewTask(cancelCtx, fullPath, r.req.Params.MethodName)
 			if err == nil {
 				g.SSEvent("message", "Your metadata extraction request is in the queue.")
 				queueing = false


### PR DESCRIPTION
This modifies the GET /metadata endpoint to use parameters instead of a request body as the latter is not common practice.