### PR TITLE
Feature/detailed transfer status

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -439,7 +439,7 @@ components:
           type: string
         status:
           type: string
-          enum: [waiting, transferring, finished, failed, cancelled, invalid state]
+          enum: [waiting, transferring, finished, failed, cancelled, invalid status]
         message:
           type: string
         bytesTransferred:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -437,9 +437,9 @@ components:
       properties:
         transferId:
           type: string
-        state:
+        status:
           type: string
-          enum: [waiting, started, finished, failed, cancelled, invalid state]
+          enum: [waiting, transferring, finished, failed, cancelled, invalid state]
         message:
           type: string
         bytesTransferred:
@@ -452,7 +452,7 @@ components:
           type: integer
       required:
         - transferId
-        - state
+        - status
     GetTransferResponse:
       type: object
       properties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -439,8 +439,22 @@ components:
           type: string
         status:
           type: string
+        started:
+          type: boolean
+        finished:
+          type: boolean
+        failed:
+          type: boolean
+        bytesTransferred:
+          type: integer
+        bytesTotal:
+          type: integer
+        filesTransferred:
+          type: integer
+        filesTotal:
+          type: integer
       required:
-        - transerId
+        - transferId
     GetTransferResponse:
       type: object
       properties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -437,14 +437,11 @@ components:
       properties:
         transferId:
           type: string
-        status:
+        state:
           type: string
-        started:
-          type: boolean
-        finished:
-          type: boolean
-        failed:
-          type: boolean
+          enum: [waiting, started, finished, failed, cancelled, invalid state]
+        message:
+          type: string
         bytesTransferred:
           type: integer
         bytesTotal:
@@ -455,6 +452,7 @@ components:
           type: integer
       required:
         - transferId
+        - state
     GetTransferResponse:
       type: object
       properties:

--- a/internal/core/globus.go
+++ b/internal/core/globus.go
@@ -151,12 +151,12 @@ func GlobusTransfer(globusConf task.GlobusTransferConfig, t *task.TransferTask, 
 		totalFiles = 1 // needed because percentage meter goes NaN otherwise
 	}
 	statusMsg := "transfering"
-	var state *task.State = nil
+	var state *task.Status = nil
 	if taskCompleted {
 		f := task.Finished
 		state = &f
 	}
-	t.SetStatus(&bytesTransferred, nil, &filesTransferred, &totalFiles, state, &statusMsg)
+	t.SetDetails(&bytesTransferred, nil, &filesTransferred, &totalFiles, state, &statusMsg)
 	if taskCompleted {
 		return nil
 	}
@@ -177,7 +177,7 @@ func GlobusTransfer(globusConf task.GlobusTransferConfig, t *task.TransferTask, 
 			}
 			statusMsg = "task was cancelled"
 			*state = task.Cancelled
-			t.SetStatus(nil, nil, nil, nil, state, &statusMsg)
+			t.SetDetails(nil, nil, nil, nil, state, &statusMsg)
 			notifier.OnTaskCanceled(localTaskId)
 			return nil
 		case <-timerUpdater:
@@ -195,7 +195,7 @@ func GlobusTransfer(globusConf task.GlobusTransferConfig, t *task.TransferTask, 
 				totalFiles = 1 // needed because percentage meter goes NaN otherwise
 			}
 
-			t.SetStatus(&bytesTransferred, nil, &filesTransferred, &totalFiles, nil, nil)
+			t.SetDetails(&bytesTransferred, nil, &filesTransferred, &totalFiles, nil, nil)
 			notifier.OnTaskProgress(localTaskId, filesTransferred, totalFiles, int(time.Since(startTime).Seconds()))
 
 			if taskCompleted {

--- a/internal/core/globus.go
+++ b/internal/core/globus.go
@@ -141,6 +141,10 @@ func GlobusTransfer(globusConf task.GlobusTransferConfig, task *task.TransferTas
 	falseVal := false
 	trueVal := true
 
+	// note: the totalFiles variable here uses the count returned by Globus
+	//   this can change over the course of the transfer, as Globus succeeds in finding the files
+	//   (recursion, checking their existence...)
+
 	bytesTransferred, filesTransferred, totalFiles, taskCompleted, err = globusCheckTransfer(globusTaskId)
 	if err != nil {
 		return err

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -55,7 +55,7 @@ func (i *Status) ToStr() string {
 	case Failed:
 		return "failed"
 	default:
-		return "invalid state"
+		return "invalid status"
 	}
 }
 

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -30,10 +30,33 @@ type TaskStatus struct {
 	BytesTotal       int
 	FilesTransferred int
 	FilesTotal       int
-	Failed           bool
-	Started          bool
-	Finished         bool
-	StatusMessage    string
+	State            State
+	Message          string
+}
+
+type State int
+
+const (
+	Waiting State = iota
+	Started
+	Finished
+	Failed
+	Cancelled
+)
+
+func (i *State) ToStr() string {
+	switch *i {
+	case Waiting:
+		return "waiting"
+	case Started:
+		return "started"
+	case Finished:
+		return "finished"
+	case Failed:
+		return "failed"
+	default:
+		return "invalid state"
+	}
 }
 
 type TransferTask struct {
@@ -79,10 +102,8 @@ func (t *TransferTask) SetStatus(
 	bytesTotal *int,
 	filesTransferred *int,
 	filesTotal *int,
-	failed *bool,
-	started *bool,
-	finished *bool,
-	statusMessage *string,
+	state *State,
+	message *string,
 ) {
 	t.statusLock.Lock()
 	defer t.statusLock.Unlock()
@@ -98,17 +119,11 @@ func (t *TransferTask) SetStatus(
 	if filesTotal != nil {
 		t.status.FilesTotal = *filesTotal
 	}
-	if failed != nil {
-		t.status.Failed = *failed
+	if state != nil {
+		t.status.State = *state
 	}
-	if started != nil {
-		t.status.Started = *started
-	}
-	if finished != nil {
-		t.status.Finished = *finished
-	}
-	if statusMessage != nil {
-		t.status.StatusMessage = *statusMessage
+	if message != nil {
+		t.status.Message = *message
 	}
 }
 

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -25,31 +25,31 @@ type TaskTransferConfig struct {
 	GlobusTransferConfig
 }
 
-type TaskStatus struct {
+type TaskDetails struct {
 	BytesTransferred int
 	BytesTotal       int
 	FilesTransferred int
 	FilesTotal       int
-	State            State
+	Status           Status
 	Message          string
 }
 
-type State int
+type Status int
 
 const (
-	Waiting State = iota
-	Started
+	Waiting Status = iota
+	Transferring
 	Finished
 	Failed
 	Cancelled
 )
 
-func (i *State) ToStr() string {
+func (i *Status) ToStr() string {
 	switch *i {
 	case Waiting:
 		return "waiting"
-	case Started:
-		return "started"
+	case Transferring:
+		return "transferring"
 	case Finished:
 		return "finished"
 	case Failed:
@@ -67,7 +67,7 @@ type TransferTask struct {
 	DatasetMetadata map[string]interface{}
 	TransferMethod  TransferMethod
 	Cancel          context.CancelFunc
-	status          *TaskStatus
+	details         *TaskDetails
 	statusLock      *sync.RWMutex
 }
 
@@ -85,45 +85,45 @@ func CreateTransferTask(datasetId string, fileList []datasetIngestor.Datafile, d
 		DatasetMetadata: metadata,
 		TransferMethod:  transferMethod,
 		Cancel:          cancel,
-		status:          &TaskStatus{},
+		details:         &TaskDetails{},
 		statusLock:      &sync.RWMutex{},
 	}
 }
 
-func (t *TransferTask) GetStatus() TaskStatus {
+func (t *TransferTask) GetDetails() TaskDetails {
 	t.statusLock.RLock()
 	defer t.statusLock.RUnlock()
-	copy := *t.status
+	copy := *t.details
 	return copy
 }
 
-func (t *TransferTask) SetStatus(
+func (t *TransferTask) SetDetails(
 	bytesTransferred *int,
 	bytesTotal *int,
 	filesTransferred *int,
 	filesTotal *int,
-	state *State,
+	status *Status,
 	message *string,
 ) {
 	t.statusLock.Lock()
 	defer t.statusLock.Unlock()
 	if bytesTransferred != nil {
-		t.status.BytesTransferred = *bytesTransferred
+		t.details.BytesTransferred = *bytesTransferred
 	}
 	if bytesTotal != nil {
-		t.status.BytesTotal = *bytesTotal
+		t.details.BytesTotal = *bytesTotal
 	}
 	if filesTransferred != nil {
-		t.status.FilesTransferred = *filesTransferred
+		t.details.FilesTransferred = *filesTransferred
 	}
 	if filesTotal != nil {
-		t.status.FilesTotal = *filesTotal
+		t.details.FilesTotal = *filesTotal
 	}
-	if state != nil {
-		t.status.State = *state
+	if status != nil {
+		t.details.Status = *status
 	}
 	if message != nil {
-		t.status.Message = *message
+		t.details.Message = *message
 	}
 }
 

--- a/internal/webserver/api.gen.go
+++ b/internal/webserver/api.gen.go
@@ -27,6 +27,16 @@ const (
 	CookieAuthScopes = "cookieAuth.Scopes"
 )
 
+// Defines values for TransferItemState.
+const (
+	Cancelled    TransferItemState = "cancelled"
+	Failed       TransferItemState = "failed"
+	Finished     TransferItemState = "finished"
+	InvalidState TransferItemState = "invalid state"
+	Started      TransferItemState = "started"
+	Waiting      TransferItemState = "waiting"
+)
+
 // DeleteTransferRequest defines model for DeleteTransferRequest.
 type DeleteTransferRequest struct {
 	// TransferId id of the transfer that should be cancelled
@@ -112,16 +122,17 @@ type PostDatasetResponse struct {
 
 // TransferItem defines model for TransferItem.
 type TransferItem struct {
-	BytesTotal       *int    `json:"bytesTotal,omitempty"`
-	BytesTransferred *int    `json:"bytesTransferred,omitempty"`
-	Failed           *bool   `json:"failed,omitempty"`
-	FilesTotal       *int    `json:"filesTotal,omitempty"`
-	FilesTransferred *int    `json:"filesTransferred,omitempty"`
-	Finished         *bool   `json:"finished,omitempty"`
-	Started          *bool   `json:"started,omitempty"`
-	Status           *string `json:"status,omitempty"`
-	TransferId       string  `json:"transferId"`
+	BytesTotal       *int              `json:"bytesTotal,omitempty"`
+	BytesTransferred *int              `json:"bytesTransferred,omitempty"`
+	FilesTotal       *int              `json:"filesTotal,omitempty"`
+	FilesTransferred *int              `json:"filesTransferred,omitempty"`
+	Message          *string           `json:"message,omitempty"`
+	State            TransferItemState `json:"state"`
+	TransferId       string            `json:"transferId"`
 }
+
+// TransferItemState defines model for TransferItem.State.
+type TransferItemState string
 
 // UserInfo defines model for UserInfo.
 type UserInfo struct {
@@ -1314,55 +1325,56 @@ func (sh *strictHandler) OtherControllerGetVersion(ctx *gin.Context) {
 var swaggerSpec = []string{
 
 	"H4sIAAAAAAAC/+xaW28ctxX+KwfTAraB1UpN0j7ozVUUZ9v4AssuUFiCwx2e3WHMIcckZ9ebQP+9OLzM",
-	"ZWf2BktpHvIgQDtD8ty+cx3+luW6rLRC5Wx2+Vtm8wJL5v/9HiU6fGeYsgs0b/FzjdbRi8roCo0T6Je5",
-	"uGDG6RdHmxtROaFVdpkJDnoBrkBIq8AVzIEtdC05zBFypnKUEnk2ydymwuwys84Itczu7yeZwc+1MMiz",
-	"yw9dOnfNWj3/BXOX3U8G3NpKK4tDdq1jrrZDVl/hGsK7bZanQ9Yme6VOTIDgwBYLzN3Xi3dtjDZDaXLN",
-	"vYwD/kq0li3H3m3R9Se068dov0D3PXPMotutVh4W+P+Fw9KOchUfMGPYxv/WjskRBdJjUHU5R0PWSId3",
-	"LCGUwyWagTgNH+nwHQJdf3GG5U7vQUqJrtB8BCo/CesSSEp0jGgChgOFVhA2gmIlWsi1WohlbZCDUH6L",
-	"UEu0Tpts0mrqrwYX2WX2l/PWG8+jK56/9MfNHJZfocIkzEEFdhbu099hRzuSsYT7UeO2ftYH1j51Jc7G",
-	"FXY/Ik5HwQN2WbIm0Ybwbo422b7Q/In1lgamOAQessmWKuj9qD/E9Qed1B/QLB8zyWtXoPkRmXTFbpMg",
-	"BRH/H+NckIRMvukbbYfHtoR2xc+bXuxMGJ8ejHvxPBJO5MzdpJ9Lqee1jT93SvwfNFZotVvkVVgw5Dfu",
-	"PI7hAfE32rYxcUdipNBAa0Z8oBs4IgMxcI0mm9qieac/4YgYtDVoDhytgIU2QHFILUErmGPB5CLRoHMO",
-	"GqRhu0v37pAOTk23pIId6RauGDFO3HJwGiwqDuSHPkPBnOWf6LEXSJyenGmbEp/rTk3SlinRCu2rX/R8",
-	"+rW5uxeRBhqabxzadylYDiNgeB+P8ATHVi2YkL13c60lMuXfCbmXQnh/kIJQwha7aFjHjNvzMoLggKm+",
-	"Ss3vLZqZWuiRuFcyIUfJ45dKGLQfmfffhTYl/UdVBJ454YPuYM+ClUJuPu4M6kuxQrX7tdTLJfKPQo3r",
-	"aue+ymAwz0dyyz3LNNlz9J3REk+s0Gwd9HvQOK1YQ9vQOZjXRrjNDaWwVLvqTwKf167wLJFzhkdZ0kLW",
-	"D1isEv9GyuH3k0xEQ/ed+y1aB8/fzHwUzHVZ1opCo/CR0K0RQwU2i8Ee3s982m5+U2yhaGPRrESOU6Bo",
-	"sfWwcy5aWAtX+DOvX57d5OKKmpu0+VbRdmKHSanXtt8Ixbp2Aqx2umRO5KPFpC8rQqBMEfBzjUZgKJiE",
-	"I1tnkXQjyPM3s2zSJr/sb9OL6QXZU1eoWCWyy+zb6cX0WypVmCu8Pc5zJiUJSz+W6G1OXuT1R/5Jdd9V",
-	"WkMbDSvR+drsw7YlftAGCqa4pEREcrPaFdqIX4M1qOsAgzmKFXJYGF36Ra9n319BZfRKcG94DwoSd9Ni",
-	"IjYsLfacqXFvKbXNW8O4h8nVzdsfiKZDr/AdVMkEp5G9o8UhLXr1fnvxzRCwXuCkd7B1nqO1i1pmk6xA",
-	"xmPdK3UA8XC/QS4M+dg+Tshfvru4CD6nHKrgzvjFnVeShUC0Z/dkL88h8QCnfKpBqBWTggf7agNBbfeT",
-	"7O8PR3+mHMU/CTdoVmggtMbdIJNdfrij0FWWzGy2OSavYUvCbEaYROViiMju6IzzWAJ0nGA7xjgjcIUe",
-	"sAstOZKYps5dbTDVEWzFhGRzib3ete9NsXa60soZLSWats8eetcYJitq2LuG7zP6hmJFbLQI6BVbCuXJ",
-	"Ey9NrquFcqNt4W6iN+LXfYRfDZs7qNAzgEeR3nadbwbgYVUlo9nOf7F6C0L72sORYcYIxuKSjkfKDZho",
-	"eT7NHtajZtFrTGwltrDcT5UfstSrfDTIeHZ338P6C6pedyIwIT+B/I4qBm1HYH5lkDkE1pTEKLFE5UAo",
-	"iNnGpybKjKlypggQ3h2B9pCrWsBH4f+p+ebBjD3Spt33CxeK4vePCLexJmkP3oJpKUN2csEfA2xrIxxu",
-	"oy0YERgoXCekjMKMIiummdtxsbVF8GC2tm+sNoReM+vrhdrm6ctm4vVnzH20mDuct45A8/m2xbWxbdQl",
-	"l0ix+KtD5D5wdQDcQjZAuPATtsP4pfaEFO4r+LmuQ0xuBx5Uhl+X0OpqiFo/3+ohNoz3skc01NgUccRO",
-	"YUUSp2egjoV+z6g1mgKLLpvd7KdJzGhRqZeBmVGDzpRwwjd6TXvSb2QWUq+HtnuB7id/7jE9wNtYw1P2",
-	"7DVAYZbn6m6N+rB9waGaWUYh9hbMUi917fY1jT+FFccoIywNSEKOfAJJlGbwV+gSIcbhk5QB1Ooe7JQe",
-	"o1OxoVPBg50KVVO1pY4CrQ323qv7NDHYCeAbx4yzfnw6nC04Zj+B7qdPsILjJMw1pFgh1BX3DtCGscro",
-	"pUFrobbU3cc27EZwhOsVxRN4enNz/Wx6q2YO1kJKyKW2IannWqnQaLejk4UgHaXpBimeCZXmBg3fFMmm",
-	"t2pXdn+ZNHFUGl8IiW9YDKa7Ovrh4Ji2eRSlPs+i9J93Q/lrMNeGj86Lx9kICedV+LpzCiMN3fYEHy22",
-	"LDzGyuFE7/GOZMkz6wwyP7TGL6ys/KzJv7lM9rpVRPMS/qtrMwqyGLFB2FSpfa6xxmDKE5zpuUeGULWu",
-	"LQS+yArBtc4stSaeMzuFa5YX4UeEX4AUuLVObYy9BKbgZ7/oZ3Bs6bsZBj8T+/7BNIzvukv6n/+IY+Ig",
-	"EPL3GtbMgudkvonwIObCGDGcHA7qc0W1bu5qJr35blXEVrJS2O7VKpxFuQjb5whMrtnGAqpc81AIz5nF",
-	"f3w38cIIZyFUIcCxQsVt8nX6i1xvKrLEj2jwCUUJGT9tV9pa4aujZpn1hwYfNoE3Tk7qGQt07OWtgjPY",
-	"BggABIwwCOZtP54Hlx9T2cw9sVBqz45DFb4GbY111TJF1liKPFXagSdoUDIXvh95aVMdF1X4rMuoD8tj",
-	"bHqb9o3u13qN1xTckZN1hI16YtJqUKQLKTdQIlM2HBKqP4/ZZDwfEzkw6ykDiC4pBgvmmAzkpl1mU/Dt",
-	"8UuxMRCKoLJpOiX1miRZCJTcXsJtZh3/qGt3m03iDzQm/DBoa+luM3iqq/Bt+Bk99u87zyK7cAbxqDii",
-	"9icBM7ilcPyCee2o1H5CfssUZ4ZDuy8+CIoNOrIe+5QmVig305ZiYNFvTMQYJ+ivizjab+nG71V2Qi8N",
-	"pr3x6lHX+XopxvtOogiezNYWpjZd6/gCuDYKeYJwy8NT4YFu0EcGpjbPpjDzjygdrnW0CwnSkhQql7Uv",
-	"fVyQirkGSiMC8uiXwjbQonWS2RgQm1zldRvibqduumJ5gWex0RhpLDXkLC8IRMKGDxnRET3JeGi2/y7D",
-	"VZP1hwSe85Ww0btyKXy40fAJsdouGKhpOoISpbGzd/7NWOp8OXt53cTujgwk3iDzTQ+WixwXrJbuwVqw",
-	"NM0e5L/3Cr9UIemP1pEntcBLdL0bCM2Yz596nmYIQYMSHQ7r+vTBuG1R+1fwHmmkN34r8Xee6u24bDhi",
-	"teYuYLjo+H9tkk8b7V15hiMymqlSpyFpHt3dTw6MQ1gahCFvSox2TuUbgZRfqMZ2SBIO2+oh5Do30Y4r",
-	"/Dt3CA58M/xz+vdw079jPOUFOmi85Q80Wjp5tDgA+BReJ3DXsQ1uYQjt12inQSu5AQrOWqG/cjgddzgK",
-	"0rUlNwnXIHZNXt6nNY9o3+bezYhu/SxDWAi3Q0Co2Gb96+b1K3relE7NMKCR6mGN7AtEVruCqHJhqR7l",
-	"VOvFwvO7iwt6Y0PP6Ir2wtkDf70WJ8+Ego5smAuRaggoOaPwd2g81Ln9ePh7S14bQ+Kvdt+MPDShjpcq",
-	"H31EvX3tc9Sr4zwrifOHHVP7zlZssTs2rT4lLk22s/skY7wUKgSsePTgNkoyr+32z50r9TEjNbXi5PgT",
-	"2nA4TMZHHzQyX2pPa7/VDI/7oTakRdDtsZSgl6jQMNn9XNOeF/R+f3f/vwAAAP//sCo7SiQzAAA=",
+	"ZWf2BktpHvIgQDvk8Ny+cx3+luW6rLRC5Wx2+Vtm8wJL5v/9HiU6fGeYsgs0b/FzjdbRQmV0hcYJ9Ntc",
+	"3DDj9IujzY2onNAqu8wEB70AVyCkXeAK5sAWupYc5gg5UzlKiTybZG5TYXaZWWeEWmb395PM4OdaGOTZ",
+	"5Ycunbtmr57/grnL7icDbm2llcUhu9YxV9shq69wDWFtm+XpkLXJXqkTEyA4sMUCc/f14l0bo81Qmlxz",
+	"L+OAvxKtZcuxtS26/oR2/xjtF+i+Z45ZdLvVysMG/79wWNpRruIDZgzb+N/aMTmiQHoMqi7naMga6fCO",
+	"JYRyuEQzEKfhIx2+Q6DrL86w3Ok9SCnRFZqPQOUnYV0CSYmOEU3AcKDQCsKLoFiJFnKtFmJZG+QglH9F",
+	"qCVap002aTX1V4OL7DL7y3nrjefRFc9f+uNmDsuvUGES5qACOxv36e+wox3JWML9qHFbP+sDa5+6Emfj",
+	"CrsfEaej4AG7LFmTaENYm6NNti80f2K9pYEpDoGHbLKlClof9Ye4/6CT+gOa7WMmee0KND8ik67YbRKk",
+	"IOL/Y5wLkpDJN32j7fDYltCu+HnTi50J49ODcS+eR8KJnLmb9HMp9by28edOif+Dxgqtdou8ChuG/MY3",
+	"j2N4QPyNtm1M3JEYKTTQnhEf6AaOyEAMXKPJprZo3ulPOCIGvRo0B452wEIboDiklqAVzLFgcpFo0DkH",
+	"DdKw3aV7d0gHp6ZbUsGOdAtXjBgnbjk4DRYVB/JDn6FgzvJP9NgLJE5PzvSaEp/rTk3SlinRCu3SL3o+",
+	"/drc3YtIAw3NNw7tuxQshxEwrMcjPMGxXQsh954S1g+dsrtqCI7vV1DVJUm9ZoJglvklE2qchVDCFuFf",
+	"JkJZ1y3xhFoxKTiEw+4O2u5ovSf+xvT/3qKZqYUeCYglE3JUWvxSCYP2I/OOvdCmpP+ovMAzJ3w0Hryz",
+	"YKWQm487o/1SrFDtXpZ6uUT+UajO6lxriUzR8s73KoPBph/JX/ds0wSC0TWjJZ5Yutk66PegkVqxhrah",
+	"czCvjXCbG8ptqajVnwQ+r13hWSKvDY+ypIWsH8lYJf6NlNzvCWHB0H2vf4vWwfM3Mx8ec12WtaKYKXyI",
+	"dGvEUJrNYhaA9zOfz5vfFHQoDFk0K5HjFCiMbD3snIsW1sIV/szrl2c3ubiirie9fKvodWKHSanXtt8h",
+	"xYJ3Aqx2umRO5KNVpq83QgRNofFzjUZgqKSEI1tnkXQjyPM3s2zSZsXsb9OL6QXZU1eoWCWyy+zb6cX0",
+	"W6phmCu8Pc5zJiUJSz+W6G1OXuT1R35KBeFV2kMvGlai80Xbh21L/KANFExxSRmK5Ga1K7QRvwZrUDsC",
+	"BnMUK+SwMLr0m17Pvr+CyuiV4N7wHhQk7qbFROxkWuw5U+PeGmubt4ZxD5Orm7c/EE2HXuE7qIawcwrZ",
+	"O9oc8qVX77cX3wwB6wVOegdb5zlau6hlNskKZDwWxFIHEA/fN8iFIR/bxwn5y3cXF8HnlEMV3Bm/uPNK",
+	"shCI9rw92ctziP/AKdFqSIHf21ebmADuJ9nfH47+TDmKfxJu0KzQQOiZu0Emu/xwR6GrLJnZbHNMXsOW",
+	"hNmMMInKxRCR3dEZ57E26DjBdoxxRuAKPWAXWnIkMU2du9pgKjDYignJ5hJ7TW3fm2JRdaWVM1pKNG0D",
+	"PvSuMUxWlMO7hu8z+oZiRezACOgVWwrlyRMvTa6rhXKj/eJuojfi132EXw27PqjQM4BHkd52nW8G4GFV",
+	"JaPZzn+xegtC+/rGkSnHCMbilo5Hyg2YaHk+zR7Wo2bRa0zsMbaw3E+VH7LUxHw0yHh2d9/D+gsqa3ci",
+	"MCE/gfyOKgZtR2B+ZZA5BNbUyiixROVAKIjZxqcmyoyppKYIENaOQHvIVS3go/D/1HzzYMYe6d/u+4UL",
+	"RfH7R4TbWPe0B2/BtJQhO7ngjwG2tRFUePfRFowIDBSuE1JGYUaRFdMw7rjY2iJ4MHTbN28bQq8ZAvZC",
+	"bfP0ZTMK+zPmPlrMHQ5iR6D5fNvi2tg26pJLpFj81SFyH7g6AG4hGyBc+NHbYfxSe0IK9xX8XNchJreT",
+	"ECrDr0todTVErR989RAb5n7ZIxpqbLw4YqewI4nTM1DHQr9n1BpNgUWXzW720yRmtKjUy8DMqEFnSjjh",
+	"G72mPek3Mgup10PbvUD3kz/3mB7gbazhKXv2GqAw5HN1t0Z92L7gUM0soxB7C2apl7p2+5rGn8KOY5QR",
+	"tgYkIUc+gSRKMxEsdIkQ4/BJygBqdQ92So/RqdjQqeDBToWqqdpSR4HWBnvv1X2aGOwE8I1jxlk/Vx3O",
+	"Fhyzn0D30ydYwXES5hpSrBDqinsHaMNYZfTSoLVQW+ruYxt2IzjC9YriCTy9ubl+Nr1VMwdrISXkUtuQ",
+	"1HOtVGi029HJQpCO0nSDFM+ESnODhm+KZNNbtSu7v0yaOCqNL4TENywG010d/XCiTK95FKU+z6L0331D",
+	"+Wsw14aPDpLH2QgJ51X47HMKIw3d9gQfLbYsPMbK4UTv8Y5kyTPrDDI/zcYvrKz8rMmvXCZ73SqieQn/",
+	"1bUZBVmM2CBsqtQ+11hjMOUJzvTcI0OoWtcWAl9kheBaZ5ZaE8+ZncI1y4vwI8IvQArcWqc2xl4CU/Cz",
+	"3/QzOLb03QyDn4l9/2AaxnfdLf3vgsQxcRAI+QsPa2bBczLfRHgQc2GMGE4OB/W5olo3dzWT3ny3KmIr",
+	"WSm87tUqnEW5CK/PEZhcs40FVLnmoRCeM4v/+G7ihRHOQqhCgGOFitvk6/QXud5UZIkf0eATihIyfvOu",
+	"tLXCV0fNNusPDT5sAm+cnNQzFujYy1sFZ7ANEAAIGGEQzNt+VQ8uP6aymXtiodSeHYcqfCbaGuuqZYqs",
+	"sRR5qrQDT9CgZC58WPLSpjouqvBZl1EflsfY9DbtG93v9RqvKbgjJ+sIG/XEpNWgSBdSbqBEpmw4JFR/",
+	"HrPJeD4mcmDWUwYQXVIMFswxGchNu8ym4Nvjl2JjIBRBZdN0Suo1SbIQKLm9hNvMOv5R1+42m8QfaEz4",
+	"YdDW0t1m8FRX4aPxM3rs1zvPIrtwBvGoOKL2JwEzuKVw/IJ57ajUfkJ+yxRnhkP7XnwQFBt0ZD32KU2s",
+	"UG6mLcXAon8xEWOcoL8u4mi/pRu/UdkJLRpM78Y7SV3n66UY7zuJIngyW68wtelaxxfAtVHIE4RbHp4K",
+	"D3SDPjIwtXk2hZl/ROlwraNdSJCWpFC5rH3p44JUzDVQGhGQR78UtoEW7ZPMxoDY5Cqv2xB3O3XTFcsL",
+	"PIuNxkhjqSFneUEgEjZ8yIiO6EnGQ7P9lxyumqw/JPCcr4SN3pVL4cONhk+I1XbBQE3TEZQojZ298ytj",
+	"qfPl7OV1E7s7MpB4g8w3PVguclywWroHa8HSNHuQ/94r/FKFpD9aR57UAi/R9a4mNGM+f+p5miEEDUoM",
+	"X4T7dVf6yty2qP27eY800hu/rvg7T/V23EIcsVpzSTB8Hv+/NsmnjfauPMMRGc1UqdOQNI/u7icHxiEs",
+	"DcKQNyVGO6fyjUDKL1RjOyQJh231EHKdK2rHFf79uwT7vhn+Of17uOnfMZ7yAh003vIHGi2dPFocAHwK",
+	"rxO469gGtzCE9mu006CV3AAFZ63Q30WcjjscBenakpuEaxC7Ji/v055HtG9z72ZEt36WISyE2yEgVGyz",
+	"/nXz+hU9b0qnZhjQSPWwRvYFIqtdQVS5sFSPcqr1YuH53cUFrdjQM7qivYn2wF+vxckzoaAjG+ZCpBoC",
+	"Ss4o/B0aD3WuRR7+3pLXxpD4q91XJg9NqONty0cfUW/fBx316jjPSuL8YcfUvrMVW+yOTatPiUuT7ew+",
+	"yRgvhQoBKx49uI2SzGu7/XPnrn3MSE2tODn+hDYcDpPx0QeNzJfa09pvNcPjfqgNaRF0eywl6CUqNEx2",
+	"P9e05wW939/d/y8AAP//whWWiz0zAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/webserver/api.gen.go
+++ b/internal/webserver/api.gen.go
@@ -27,14 +27,14 @@ const (
 	CookieAuthScopes = "cookieAuth.Scopes"
 )
 
-// Defines values for TransferItemState.
+// Defines values for TransferItemStatus.
 const (
-	Cancelled    TransferItemState = "cancelled"
-	Failed       TransferItemState = "failed"
-	Finished     TransferItemState = "finished"
-	InvalidState TransferItemState = "invalid state"
-	Started      TransferItemState = "started"
-	Waiting      TransferItemState = "waiting"
+	Cancelled    TransferItemStatus = "cancelled"
+	Failed       TransferItemStatus = "failed"
+	Finished     TransferItemStatus = "finished"
+	InvalidState TransferItemStatus = "invalid state"
+	Transferring TransferItemStatus = "transferring"
+	Waiting      TransferItemStatus = "waiting"
 )
 
 // DeleteTransferRequest defines model for DeleteTransferRequest.
@@ -122,17 +122,17 @@ type PostDatasetResponse struct {
 
 // TransferItem defines model for TransferItem.
 type TransferItem struct {
-	BytesTotal       *int              `json:"bytesTotal,omitempty"`
-	BytesTransferred *int              `json:"bytesTransferred,omitempty"`
-	FilesTotal       *int              `json:"filesTotal,omitempty"`
-	FilesTransferred *int              `json:"filesTransferred,omitempty"`
-	Message          *string           `json:"message,omitempty"`
-	State            TransferItemState `json:"state"`
-	TransferId       string            `json:"transferId"`
+	BytesTotal       *int               `json:"bytesTotal,omitempty"`
+	BytesTransferred *int               `json:"bytesTransferred,omitempty"`
+	FilesTotal       *int               `json:"filesTotal,omitempty"`
+	FilesTransferred *int               `json:"filesTransferred,omitempty"`
+	Message          *string            `json:"message,omitempty"`
+	Status           TransferItemStatus `json:"status"`
+	TransferId       string             `json:"transferId"`
 }
 
-// TransferItemState defines model for TransferItem.State.
-type TransferItemState string
+// TransferItemStatus defines model for TransferItem.Status.
+type TransferItemStatus string
 
 // UserInfo defines model for UserInfo.
 type UserInfo struct {
@@ -1325,56 +1325,56 @@ func (sh *strictHandler) OtherControllerGetVersion(ctx *gin.Context) {
 var swaggerSpec = []string{
 
 	"H4sIAAAAAAAC/+xaW28ctxX+KwfTAraB1UpN0j7ozVUUZ9v4AssuUFiCwx2e3WHMIcckZ9ebQP+9OLzM",
-	"ZWf2BktpHvIgQDvk8Ny+cx3+luW6rLRC5Wx2+Vtm8wJL5v/9HiU6fGeYsgs0b/FzjdbRQmV0hcYJ9Ntc",
-	"3DDj9IujzY2onNAqu8wEB70AVyCkXeAK5sAWupYc5gg5UzlKiTybZG5TYXaZWWeEWmb395PM4OdaGOTZ",
-	"5Ycunbtmr57/grnL7icDbm2llcUhu9YxV9shq69wDWFtm+XpkLXJXqkTEyA4sMUCc/f14l0bo81Qmlxz",
-	"L+OAvxKtZcuxtS26/oR2/xjtF+i+Z45ZdLvVysMG/79wWNpRruIDZgzb+N/aMTmiQHoMqi7naMga6fCO",
-	"JYRyuEQzEKfhIx2+Q6DrL86w3Ok9SCnRFZqPQOUnYV0CSYmOEU3AcKDQCsKLoFiJFnKtFmJZG+QglH9F",
-	"qCVap002aTX1V4OL7DL7y3nrjefRFc9f+uNmDsuvUGES5qACOxv36e+wox3JWML9qHFbP+sDa5+6Emfj",
-	"CrsfEaej4AG7LFmTaENYm6NNti80f2K9pYEpDoGHbLKlClof9Ye4/6CT+gOa7WMmee0KND8ik67YbRKk",
-	"IOL/Y5wLkpDJN32j7fDYltCu+HnTi50J49ODcS+eR8KJnLmb9HMp9by28edOif+Dxgqtdou8ChuG/MY3",
-	"j2N4QPyNtm1M3JEYKTTQnhEf6AaOyEAMXKPJprZo3ulPOCIGvRo0B452wEIboDiklqAVzLFgcpFo0DkH",
-	"DdKw3aV7d0gHp6ZbUsGOdAtXjBgnbjk4DRYVB/JDn6FgzvJP9NgLJE5PzvSaEp/rTk3SlinRCu3SL3o+",
-	"/drc3YtIAw3NNw7tuxQshxEwrMcjPMGxXQsh954S1g+dsrtqCI7vV1DVJUm9ZoJglvklE2qchVDCFuFf",
-	"JkJZ1y3xhFoxKTiEw+4O2u5ovSf+xvT/3qKZqYUeCYglE3JUWvxSCYP2I/OOvdCmpP+ovMAzJ3w0Hryz",
-	"YKWQm487o/1SrFDtXpZ6uUT+UajO6lxriUzR8s73KoPBph/JX/ds0wSC0TWjJZ5Yutk66PegkVqxhrah",
-	"czCvjXCbG8ptqajVnwQ+r13hWSKvDY+ypIWsH8lYJf6NlNzvCWHB0H2vf4vWwfM3Mx8ec12WtaKYKXyI",
-	"dGvEUJrNYhaA9zOfz5vfFHQoDFk0K5HjFCiMbD3snIsW1sIV/szrl2c3ubiirie9fKvodWKHSanXtt8h",
-	"xYJ3Aqx2umRO5KNVpq83QgRNofFzjUZgqKSEI1tnkXQjyPM3s2zSZsXsb9OL6QXZU1eoWCWyy+zb6cX0",
-	"W6phmCu8Pc5zJiUJSz+W6G1OXuT1R35KBeFV2kMvGlai80Xbh21L/KANFExxSRmK5Ga1K7QRvwZrUDsC",
-	"BnMUK+SwMLr0m17Pvr+CyuiV4N7wHhQk7qbFROxkWuw5U+PeGmubt4ZxD5Orm7c/EE2HXuE7qIawcwrZ",
-	"O9oc8qVX77cX3wwB6wVOegdb5zlau6hlNskKZDwWxFIHEA/fN8iFIR/bxwn5y3cXF8HnlEMV3Bm/uPNK",
-	"shCI9rw92ctziP/AKdFqSIHf21ebmADuJ9nfH47+TDmKfxJu0KzQQOiZu0Emu/xwR6GrLJnZbHNMXsOW",
-	"hNmMMInKxRCR3dEZ57E26DjBdoxxRuAKPWAXWnIkMU2du9pgKjDYignJ5hJ7TW3fm2JRdaWVM1pKNG0D",
-	"PvSuMUxWlMO7hu8z+oZiRezACOgVWwrlyRMvTa6rhXKj/eJuojfi132EXw27PqjQM4BHkd52nW8G4GFV",
-	"JaPZzn+xegtC+/rGkSnHCMbilo5Hyg2YaHk+zR7Wo2bRa0zsMbaw3E+VH7LUxHw0yHh2d9/D+gsqa3ci",
-	"MCE/gfyOKgZtR2B+ZZA5BNbUyiixROVAKIjZxqcmyoyppKYIENaOQHvIVS3go/D/1HzzYMYe6d/u+4UL",
-	"RfH7R4TbWPe0B2/BtJQhO7ngjwG2tRFUePfRFowIDBSuE1JGYUaRFdMw7rjY2iJ4MHTbN28bQq8ZAvZC",
-	"bfP0ZTMK+zPmPlrMHQ5iR6D5fNvi2tg26pJLpFj81SFyH7g6AG4hGyBc+NHbYfxSe0IK9xX8XNchJreT",
-	"ECrDr0todTVErR989RAb5n7ZIxpqbLw4YqewI4nTM1DHQr9n1BpNgUWXzW720yRmtKjUy8DMqEFnSjjh",
-	"G72mPek3Mgup10PbvUD3kz/3mB7gbazhKXv2GqAw5HN1t0Z92L7gUM0soxB7C2apl7p2+5rGn8KOY5QR",
-	"tgYkIUc+gSRKMxEsdIkQ4/BJygBqdQ92So/RqdjQqeDBToWqqdpSR4HWBnvv1X2aGOwE8I1jxlk/Vx3O",
-	"Fhyzn0D30ydYwXES5hpSrBDqinsHaMNYZfTSoLVQW+ruYxt2IzjC9YriCTy9ubl+Nr1VMwdrISXkUtuQ",
-	"1HOtVGi029HJQpCO0nSDFM+ESnODhm+KZNNbtSu7v0yaOCqNL4TENywG010d/XCiTK95FKU+z6L0331D",
-	"+Wsw14aPDpLH2QgJ51X47HMKIw3d9gQfLbYsPMbK4UTv8Y5kyTPrDDI/zcYvrKz8rMmvXCZ73SqieQn/",
-	"1bUZBVmM2CBsqtQ+11hjMOUJzvTcI0OoWtcWAl9kheBaZ5ZaE8+ZncI1y4vwI8IvQArcWqc2xl4CU/Cz",
-	"3/QzOLb03QyDn4l9/2AaxnfdLf3vgsQxcRAI+QsPa2bBczLfRHgQc2GMGE4OB/W5olo3dzWT3ny3KmIr",
-	"WSm87tUqnEW5CK/PEZhcs40FVLnmoRCeM4v/+G7ihRHOQqhCgGOFitvk6/QXud5UZIkf0eATihIyfvOu",
-	"tLXCV0fNNusPDT5sAm+cnNQzFujYy1sFZ7ANEAAIGGEQzNt+VQ8uP6aymXtiodSeHYcqfCbaGuuqZYqs",
-	"sRR5qrQDT9CgZC58WPLSpjouqvBZl1EflsfY9DbtG93v9RqvKbgjJ+sIG/XEpNWgSBdSbqBEpmw4JFR/",
-	"HrPJeD4mcmDWUwYQXVIMFswxGchNu8ym4Nvjl2JjIBRBZdN0Suo1SbIQKLm9hNvMOv5R1+42m8QfaEz4",
-	"YdDW0t1m8FRX4aPxM3rs1zvPIrtwBvGoOKL2JwEzuKVw/IJ57ajUfkJ+yxRnhkP7XnwQFBt0ZD32KU2s",
-	"UG6mLcXAon8xEWOcoL8u4mi/pRu/UdkJLRpM78Y7SV3n66UY7zuJIngyW68wtelaxxfAtVHIE4RbHp4K",
-	"D3SDPjIwtXk2hZl/ROlwraNdSJCWpFC5rH3p44JUzDVQGhGQR78UtoEW7ZPMxoDY5Cqv2xB3O3XTFcsL",
-	"PIuNxkhjqSFneUEgEjZ8yIiO6EnGQ7P9lxyumqw/JPCcr4SN3pVL4cONhk+I1XbBQE3TEZQojZ298ytj",
-	"qfPl7OV1E7s7MpB4g8w3PVguclywWroHa8HSNHuQ/94r/FKFpD9aR57UAi/R9a4mNGM+f+p5miEEDUoM",
-	"X4T7dVf6yty2qP27eY800hu/rvg7T/V23EIcsVpzSTB8Hv+/NsmnjfauPMMRGc1UqdOQNI/u7icHxiEs",
-	"DcKQNyVGO6fyjUDKL1RjOyQJh231EHKdK2rHFf79uwT7vhn+Of17uOnfMZ7yAh003vIHGi2dPFocAHwK",
-	"rxO469gGtzCE9mu006CV3AAFZ63Q30WcjjscBenakpuEaxC7Ji/v055HtG9z72ZEt36WISyE2yEgVGyz",
-	"/nXz+hU9b0qnZhjQSPWwRvYFIqtdQVS5sFSPcqr1YuH53cUFrdjQM7qivYn2wF+vxckzoaAjG+ZCpBoC",
-	"Ss4o/B0aD3WuRR7+3pLXxpD4q91XJg9NqONty0cfUW/fBx316jjPSuL8YcfUvrMVW+yOTatPiUuT7ew+",
-	"yRgvhQoBKx49uI2SzGu7/XPnrn3MSE2tODn+hDYcDpPx0QeNzJfa09pvNcPjfqgNaRF0eywl6CUqNEx2",
-	"P9e05wW939/d/y8AAP//whWWiz0zAAA=",
+	"ZWf2BktpHvIgQDtD8ty+cx3+luW6rLRC5Wx2+Vtm8wJL5v/9HiU6fGeYsgs0b/FzjdbRi8roCo0T6Je5",
+	"uGDG6RdHmxtROaFVdpkJDnoBrkBIq8AVzIEtdC05zBFypnKUEnk2ydymwuwys84Itczu7yeZwc+1MMiz",
+	"yw9dOnfNWj3/BXOX3U8G3NpKK4tDdq1jrrZDVl/hGsK7bZanQ9Yme6VOTIDgwBYLzN3Xi3dtjDZDaXLN",
+	"vYwD/kq0li3H3m3R9Se068dov0D3PXPMotutVh4W+P+Fw9KOchUfMGPYxv/WjskRBdJjUHU5R0PWSId3",
+	"LCGUwyWagTgNH+nwHQJdf3GG5U7vQUqJrtB8BCo/CesSSEp0jGgChgOFVhA2gmIlWsi1WohlbZCDUH6L",
+	"UEu0Tpts0mrqrwYX2WX2l/PWG8+jK56/9MfNHJZfocIkzEEFdhbu099hRzuSsYT7UeO2ftYH1j51Jc7G",
+	"FXY/Ik5HwQN2WbIm0Ybwbo422b7Q/In1lgamOAQessmWKuj9qD/E9Qed1B/QLB8zyWtXoPkRmXTFbpMg",
+	"BRH/H+NckIRMvukbbYfHtoR2xc+bXuxMGJ8ejHvxPBJO5MzdpJ9Lqee1jT93SvwfNFZotVvkVVgw5Dfu",
+	"PI7hAfE32rYxcUdipNBAa0Z8oBs4IgMxcI0mm9qieac/4YgYtDVoDhytgIU2QHFILUErmGPB5CLRoHMO",
+	"GqRhu0v37pAOTk23pIId6RauGDFO3HJwGiwqDuSHPkPBnOWf6LEXSJyenGmbEp/rTk3SlinRCu2rX/R8",
+	"+rW5uxeRBhqabxzadylYDiNgeB+P8ATHVi2E3HtKeH/olN1VQ9fxUdUlib1mgnCWtQo34edCKGELX/Qs",
+	"mAjFXbfQE2rFpOAeAN2SY5cFj9Z+w+WYGd5bNDO10CNxsWRCjgqNXyph0H5k3r8X2pT0H1UZeOaED8qD",
+	"PQtWCrn5uDPoL8UK1e7XUi+XyD8K1Xk711oiU/R6577KYDDtR3LbPcs0YWH0ndEST6zgbB30e9BKrVhD",
+	"29A5mNdGuM0NpbhU2+pPAp/XrvAskfOGR1nSQtYPaKwS/0bK8fcEsWDovvO/Revg+ZuZj5K5LstaUegU",
+	"PlK6NWKo0GYxGcD7mU/rzW+KPRSNLJqVyHEKFE22HnbORQtr4Qp/5vXLs5tcXFHzkzbfKtpO7DAp9dr2",
+	"G6VY906A1U6XzIl8tNj0ZUcIpClCfq7RCAwFlXBk6yySbgR5/maWTdrkmP1tejG9IHvqChWrRHaZfTu9",
+	"mH5LpQxzhbfHec6kJGHpxxK9zcmLvP7IUakuvEpraKNhJTpfu33YtsQP2kDBFJeUqEhuVrtCG/FrsAZ1",
+	"JWAwR7FCDgujS7/o9ez7K6iMXgnuDe9BQeJuWkzEhqbFnjM17i21tnlrGPcwubp5+wPRdOgVvoNqCGWn",
+	"kL2jxSFtevV+e/HNELBe4KR3sHWeo7WLWmaTrEDGY10sdQDxcL9BLgz52D5OyF++u7gIPqccquDO+MWd",
+	"V5KFQLRn92QvzyEBAKd8qyFFfm9fbWIGuJ9kf384+jPlKP5JuEGzQgOhde4Gmezywx2FrrJkZrPNMXkN",
+	"WxJmM8IkKhdDRHZHZ5zHEqHjBNsxxhmBK/SAXWjJkcQ0de5qg6nOYCsmJJtL7PW2fW+KtdWVVs5oKdG0",
+	"ffjQu8YwWVEq7xq+z+gbihWxESOgV2wplCdPvDS5rhbKjbaNu4neiF/3EX41bP6gQs8AHkV623W+GYCH",
+	"VZWMZjv/xeotCO1rH0eGHSMYi0s6Hik3YKLl+TR7WI+aRa8xsdXYwnI/VX7IUi/z0SDj2d19D+svqLrd",
+	"icCE/ATyO6oYtB2B+ZVB5hBYUzKjxBKVA6EgZhufmigzpsqaIkB4dwTaQ65qAR+F/6fmmwcz9kgbd98v",
+	"XCiK3z8i3MaaqD14C6alDNnJBX8MsK2NoGK+j7ZgRGCgcJ2QMgoziqyYZnLHxdYWwYPZ276x2xB6zSyw",
+	"F2qbpy+bidifMffRYu5wHjsCzefbFtfGtlGXXCLF4q8OkfvA1QFwC9kA4cJP4A7jl9oTUriv4Oe6DjG5",
+	"HYhQGX5dQqurIWr9/KuH2DD+yx7RUGNTxhE7hRVJnJ6BOhb6PaPWaAosumx2s58mMaNFpV4GZkYNOlPC",
+	"Cd/oNe1Jv5FZSL0e2u4Fup/8ucf0AG9jDU/Zs9cAhVmfq7s16sP2BYdqZhmF2FswS73UtdvXNP4UVhyj",
+	"jLA0IAk58gkkUZrBYKFLhBiHT1IGUKt7sFN6jE7Fhk4FD3YqVE3VljoKtDbYe6/u08RgJ4BvHDPO+vHq",
+	"cLbgmP0Eup8+wQqOkzDXkGKFUFfcO0AbxiqjlwathdpSdx/bsBvBEa5XFE/g6c3N9bPprZo5WAspIZfa",
+	"hqSea6VCo92OThaCdJSmG6R4JlSaGzR8UySb3qpd2f1l0sRRaXwhJL5hMZju6uiHg2Xa5lGU+jyL0n/+",
+	"DeWvwVwbPjpPHmcjJJxX4evPKYw0dNsTfLTYsvAYK4cTvcc7kiXPrDPI/FAbv7Cy8rMm/+Yy2etWEc1L",
+	"+K+uzSjIYsQGYVOl9rnGGoMpT3Cm5x4ZQtW6thD4IisE1zqz1Jp4zuwUrllehB8RfgFS4NY6tTH2EpiC",
+	"n/2in8Gxpe9mGPxM7PsH0zC+6y7pfx4kjomDQMjfe1gzC56T+SbCg5gLY8RwcjiozxXVurmrmfTmu1UR",
+	"W8lKYbtXq3AW5SJsnyMwuWYbC6hyzUMhPGcW//HdxAsjnIVQhQDHChW3ydfpL3K9qcgSP6LBJxQlZPz0",
+	"XWlrha+OmmXWHxp82ATeODmpZyzQsZe3Cs5gGyAAEDDCIJi3/bgeXH5MZTP3xEKpPTsOVfhatDXWVcsU",
+	"WWMp8lRpB56gQclc+L7kpU11XFThsy6jPiyPselt2je6X+s1XlNwR07WETbqiUmrQZEupNxAiUzZcEio",
+	"/jxmk/F8TOTArKcMILqkGCyYYzKQm3aZTcG3xy/FxkAogsqm6ZTUa5JkIVByewm3mXX8o67dbTaJP9CY",
+	"8MOgraW7zeCprsK342f02L/vPIvswhnEo+KI2p8EzOCWwvEL5rWjUvsJ+S1TnBkO7b74ICg26Mh67FOa",
+	"WKHcTFuKgUW/MRFjnKC/LuJov6UbP1LZCb00mPbGq0ld5+ulGO87iSJ4MltbmNp0reML4Noo5AnCLQ9P",
+	"hQe6QR8ZmNo8m8LMP6J0uNbRLiRIS1KoXNa+9HFBKuYaKI0IyKNfCttAi9ZJZmNAbHKV122Iu5266Yrl",
+	"BZ7FRmOksdSQs7wgEAkbPmRER/Qk46HZ/rsOV03WHxJ4zlfCRu/KpfDhRsMnxGq7YKCm6QhKlMbO3vk3",
+	"Y6nz5ezldRO7OzKQeIPMNz1YLnJcsFq6B2vB0jR7kP/eK/xShaQ/Wkee1AIv0fVuKDRjPn/qeZohBA1K",
+	"dDis69PH5rZF7V/Re6SR3vitxd95qrfjMuKI1Zq7guH7+P+1ST5ttHflGY7IaKZKnYakeXR3PzkwDmFp",
+	"EIa8KTHaOZVvBFJ+oRrbIUk4bKuHkOvcVDuu8O9fJtj3zfDP6d/DTf+O8ZQX6KDxlj/QaOnk0eIA4FN4",
+	"ncBdxza4hSG0X6OdBq3kBig4a4X+SuJ03OEoSNeW3CRcg9g1eXmf1jyifZt7NyO69bMMYSHcDgGhYpv1",
+	"r5vXr+h5Uzo1w4BGqoc1si8QWe0KosqFpXqUU60XC8/vLi7ojQ09oyvaC2kP/PVanDwTCjqyYS5EqiGg",
+	"5IzC36HxUOd25OHvLXltDIm/2n1z8tCEOl66fPQR9fa10FGvjvOsJM4fdkztO1uxxe7YtPqUuDTZzu6T",
+	"jPFSqBCw4tGD2yjJvLbbP3eu3MeM1NSKk+NPaMPhMBkffdDIfKk9rf1WMzzuh9qQFkG3x1KCXqJCw2T3",
+	"c017XtD7/d39/wIAAP//7w1XRUQzAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/webserver/api.gen.go
+++ b/internal/webserver/api.gen.go
@@ -112,8 +112,15 @@ type PostDatasetResponse struct {
 
 // TransferItem defines model for TransferItem.
 type TransferItem struct {
-	Status     *string `json:"status,omitempty"`
-	TransferId *string `json:"transferId,omitempty"`
+	BytesTotal       *int    `json:"bytesTotal,omitempty"`
+	BytesTransferred *int    `json:"bytesTransferred,omitempty"`
+	Failed           *bool   `json:"failed,omitempty"`
+	FilesTotal       *int    `json:"filesTotal,omitempty"`
+	FilesTransferred *int    `json:"filesTransferred,omitempty"`
+	Finished         *bool   `json:"finished,omitempty"`
+	Started          *bool   `json:"started,omitempty"`
+	Status           *string `json:"status,omitempty"`
+	TransferId       string  `json:"transferId"`
 }
 
 // UserInfo defines model for UserInfo.
@@ -1306,56 +1313,56 @@ func (sh *strictHandler) OtherControllerGetVersion(ctx *gin.Context) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xaW28ctxX+KwfTAraB1UpN0j7ozVUUZ9v4AisuUFiCwx2e3WHMIcckZ9ebQP+9OLzM",
-	"ZWf2BkupH/IgQDvD4bl950r+nuW6rLRC5Wx2+Xtm8wJL5v/9HiU6/NkwZRdo3uKnGq2jF5XRFRon0C9z",
-	"ccGM0y+ONjeickKr7DITHPQCXIGQVoErmANb6FpymCPkTOUoJfJskrlNhdllZp0Rapnd308yg59qYZBn",
-	"l++7dO6atXr+K+Yuu58MuLWVVhaH7FrHXG2HrL7CNYR32yxPh6xN9kqdmADBgS0WmLsvF+/aGG2G0uSa",
-	"exkH/JVoLVuOvdui63do14/RfoHue+aYRbdbrTws8P8Lh6Ud5So+YMawjf+tHZMjCqTHoOpyjoaskTbv",
-	"WEIoh0s0A3EaPtLmOwS6/uwMy53eg5QSXaH5CFR+EtYlkJToGNEEDBsKrSB8CIqVaCHXaiGWtUEOQvlP",
-	"hFqiddpkk1ZTfzW4yC6zv5y33ngeXfH8pd9u5rD8AhUmYQ4qsLNwn/4OO9qRjCXcjxq39bM+sPapK3E2",
-	"rrD7EXE6Ch6wy5I1iTaEd3O0yfaF5k+stzQwxSHwkE22VEHvR/0hrj/opH6DZvmYSV67As2PyKQrdpsE",
-	"KYj4/xjngiRk8k3faDs8tiW0K37e9GJnwvj0YNyL+5FwImfuJv1cSj2vbfy5U+L/oLFCq90ir8KCIb/x",
-	"y+MYHhB/o20bE3ckRgoNtGbEB7qBIzIQA9dosqktmp/1RxwRgz4NmgNHK2ChDVAcUkvQCuZYMLlINGif",
-	"gwZp2O7SvTukg1PTLalgR7qFK0aME7ccnAaLigP5oc9QMGf5R3rsBRKnJ2f6TIlPdacmacuUaIX21a96",
-	"Pv3S3N2LSHs0dECOI3jYycI7eqUWeiQmlEzIUer4uRIG7Qfmsb3QpqT/KMPimRM+IA2+WbBSyM2HnQFv",
-	"KVaodr+WerlE/kGoztu51hKZotc7v6sMLtAY5B8IsnuW6YWQ4++Mlnhi9WLroN+DtmnFGtqG9sG8NsJt",
-	"bii8p7pOfxT4vHaFZ4mAGx5lSQtZ35lZJf6NlN/uJ5mIhu4D/y1aB8/fzHyEyHVZ1orChvBRwq0RQ3Uy",
-	"i4EQ3s18Smt+k9+RJ1o0K5HjFMiTth529kULa+EKv+f1y7ObXFxR4Z8+vlX0ObHDpNRr228SYs03AVY7",
-	"XTIn8tFCy6fcEERSdPhUoxEYignhyNZZJN0I8vzNLJu0iSH72/RiekH21BUqVonsMvt2ejH9ltI4c4W3",
-	"x3nOpCRh6ccSvc3Ji7z+yD2pJrpKa+hDw0p0vm55v22JH7SBgikuKUiT3Kx2hTbit2ANqsjBYI5ihRwW",
-	"Rpd+0evZ91dQGb0S3Bveg4LE3bSYiMV8iz1natxbZmzz1jDuYXJ18/YHounQK3wHVTLBaWTvaHFIGV69",
-	"3158MwSsFzjpHWyd52jtopbZJCuQ8VgTSh1APPzeIBeGfGwfJ+Qv311cBJ9TDlVwZ/zszivJQiDa8/Vk",
-	"L88LJiRy4JRrNAi1YlLwYF9tIKjtfpL9/eHoz5Sj+CfhBs0KDYS2sRtkssv3dxS6ypKZzTbH5DVsSZjN",
-	"CJOoXAwR2R3tcR7TY8cJtmOMMwJX6AG70JIjiWnq3NUGU45lKyYkm0vs9XV9b4p1xZVWzmgp0bQ96NC7",
-	"xjBZUTPbNXyf0TcUK2ITQkCv2FIoT554aXJdLZQbbZl2E70Rv+0j/GrY+ECFngE8ivS263wzAA+rKhnN",
-	"dv6r1VsQ2tc6jTT6IxiLSzoeKTdgouX5NHtYj5pFrzGxzN7Ccj9Vvs9SHf/BIOPZ3X0P6y+ostuJwIT8",
-	"BPI7qhi0HYH5lUHmEFhTLqLEEpWjDj9mG5+aKDOmqpIiQHh3BNpDrmoBH4X/p+abBzP2SAtz3y9cKIrf",
-	"PyLcxhqIPXgLpqUM2ckFXwfY1kY43EZbMCIwULhOSBmFGUVWTPOo42Jri+DB3GnfyGkIvWYO1gu1zdOX",
-	"zTToz5j7aDF3OIscgebzbYtrY9uoSy6RYvEXh8h94OoAuIVsgHDhp0+H8UvtCSncV/BzXYeY3A4DqAy/",
-	"LqHV1RC1fvbTQ2wYfWWPaKixCduIncKKJE7PQB0L/ZFRazQFFl02u9lPk5jRolIvAzOjBp0p4YRv9Jr2",
-	"pN/ILKReD233At1Pft9jeoC3sYan7NlrgMKcy9XdGvVh+4JDNbOMQuwtmKVe6trtaxp/CiuOUUZYGpCE",
-	"HPkEkijNUKzQJUKMwycpA6jVPdgpPUanYkOnggc7FaqmaksdBVob7L1X92lisBPAN44ZZ/1ocThbcMx+",
-	"BN1Pn2AFx0mYa0ixQqgr7h2gDWOV0UuD1kJtqbuPbdiN4AjXK4on8PTm5vrZ9FbNHKyFlJBLbUNSz7VS",
-	"odFuRycLQTpK0w1SPBMqzQ0avimSTW/Vruz+MmniqDS+EBLfsBhMd3X0w6EqfeZRlPo8i9IffYby12Cu",
-	"DR+dpY6zERLOq3DycQojDd12Bx8ttiw8xsrhRO/xjmTJM+sMMj/Qxc+srPysyb+5TPa6VUTzEv6razMK",
-	"shixQdhUqX2qscZgyhOc6blHhlC1ri0EvsgKwbXOLLUmnjM7hWuWF+FHhF+AFLi1Tm2MvQSm4Be/6Bdw",
-	"bOm7GQa/EPv+wTSM77pL+kdjxDFxEAj5M/81s+A5mW8iPIi5MEYMO4eN+lxRrZu7mklvvlsVsZWsFD73",
-	"ahXOolyEz+cITK7ZxgKqXPNQCM+ZxX98N/HCCGchVCHAsULFbfJ1+otcbyqyxI9o8AlFCRmPfSttrfDV",
-	"UbPM+k2DD5vAGycn9YwFOvbyVsEZbAMEAAJGGATztgfLweXHVDZzTyyU2rPjUIWTkq2xrlqmyBpLkadK",
-	"O/AEDUrmwtmKlzbVcVGFz7qM+rA8xqa3ad/ofq3XeE3BHTlZR9ioJyatBkW6kHIDJTJlwyah+vOYTcbz",
-	"MZEDs54ygOiSYrBgjslAbtplNgXfHr8UGwOhCCqbplNSr0mShUDJ7SXcZtbxD7p2t9kk/kBjwg+Dtpbu",
-	"NoOnugrnps/osX/feRbZhTOIW8URtd8JmMEtheNnzGtHpfYT8lumODMc2u/ig6DYoCPrsU9pYoVyM20p",
-	"Bhb9h4kY4wT9dRFH+y3dhVDCFmgn9NJg+jZey+k6Xy/FeN9JFMGT2fqEqU3XOr4Aro1CniDc8vBUeKAb",
-	"9JGBqc2zKcz8I0qHax3tQoK0JIXKZe1LHxekYq6B0oiAPPqlsA20aJ1kNgbEJld53Ya426mbrlhe4Fls",
-	"NEYaSw05ywsCkbDhICM6oicZN832n/NfNVl/SOA5XwkbvSuXwocbDR8Rq+2CgZqmIyhRGjv72b8ZS50v",
-	"Zy+vm9jdkYHEG2S+6cFykeOC1dI9WAuWptmD/PdO4ecqJP3ROvKkFniJrnc634z5/K7naYYQNCjR4bCu",
-	"Tye+bYvav572SCO98Rt7f/BUb8dFvBGrNffkwiXA/2uTfNpo78ozHJHRTJU6DUnz6O5+cmAcwtIgDHlT",
-	"YrRzKt8IpPxCNbZDknDYVg8h17mldVzh37lucODM8M/p38NN/47xlBfooPGWr2i0dPJocQDwKbxO4K5j",
-	"G9zCENrTaKdBK7kBCs5aob+ONx13OArStSU3Cdcgdk1e3qU1j2jf5t7NiG79LENYCLdDQKjYZv3r5vUr",
-	"et6UTs0woJHqYY3sC0RWu4KocmGpHuVU68XC87uLC3pjQ8/oivYy1gOfXouTZ0JBRzbMhUg1BJScUfg7",
-	"NB7q3Aw8fN6S18aQ+KvdtwYPTajjhcNHH1FvX4kc9eo4z0rifLVjat/Zii12x6bVp8SlyXZ2n2SMl0KF",
-	"gBW3HtxGSea13f65c908ZqSmVpwcv0MbDofJ+OiNRuZL7W7tWc1wux9qQ1oE3W5LCXqJCg2T3eOadr+g",
-	"9/u7+/8FAAD//4x9wzBAMgAA",
+	"H4sIAAAAAAAC/+xaW28ctxX+KwfTAraB1UpN0j7ozVUUZ9v4AssuUFiCwx2e3WHMIcckZ9ebQP+9OLzM",
+	"ZWf2BktpHvIgQDtD8ty+cx3+luW6rLRC5Wx2+Vtm8wJL5v/9HiU6fGeYsgs0b/FzjdbRi8roCo0T6Je5",
+	"uGDG6RdHmxtROaFVdpkJDnoBrkBIq8AVzIEtdC05zBFypnKUEnk2ydymwuwys84Itczu7yeZwc+1MMiz",
+	"yw9dOnfNWj3/BXOX3U8G3NpKK4tDdq1jrrZDVl/hGsK7bZanQ9Yme6VOTIDgwBYLzN3Xi3dtjDZDaXLN",
+	"vYwD/kq0li3H3m3R9Se068dov0D3PXPMotutVh4W+P+Fw9KOchUfMGPYxv/WjskRBdJjUHU5R0PWSId3",
+	"LCGUwyWagTgNH+nwHQJdf3GG5U7vQUqJrtB8BCo/CesSSEp0jGgChgOFVhA2gmIlWsi1WohlbZCDUH6L",
+	"UEu0Tpts0mrqrwYX2WX2l/PWG8+jK56/9MfNHJZfocIkzEEFdhbu099hRzuSsYT7UeO2ftYH1j51Jc7G",
+	"FXY/Ik5HwQN2WbIm0Ybwbo422b7Q/In1lgamOAQessmWKuj9qD/E9Qed1B/QLB8zyWtXoPkRmXTFbpMg",
+	"BRH/H+NckIRMvukbbYfHtoR2xc+bXuxMGJ8ejHvxPBJO5MzdpJ9Lqee1jT93SvwfNFZotVvkVVgw5Dfu",
+	"PI7hAfE32rYxcUdipNBAa0Z8oBs4IgMxcI0mm9qieac/4YgYtDVoDhytgIU2QHFILUErmGPB5CLRoHMO",
+	"GqRhu0v37pAOTk23pIId6RauGDFO3HJwGiwqDuSHPkPBnOWf6LEXSJyenGmbEp/rTk3SlinRCu2rX/R8",
+	"+rW5uxeRBhqabxzadylYDiNgeB+P8ATHVi2YkL13c60lMuXfCbmXQnh/kIJQwha7aFjHjNvzMoLggKm+",
+	"Ss3vLZqZWuiRuFcyIUfJ45dKGLQfmfffhTYl/UdVBJ454YPuYM+ClUJuPu4M6kuxQrX7tdTLJfKPQo3r",
+	"aue+ymAwz0dyyz3LNNlz9J3REk+s0Gwd9HvQOK1YQ9vQOZjXRrjNDaWwVLvqTwKf167wLJFzhkdZ0kLW",
+	"D1isEv9GyuH3k0xEQ/ed+y1aB8/fzHwUzHVZ1opCo/CR0K0RQwU2i8Ee3s982m5+U2yhaGPRrESOU6Bo",
+	"sfWwcy5aWAtX+DOvX57d5OKKmpu0+VbRdmKHSanXtt8Ixbp2Aqx2umRO5KPFpC8rQqBMEfBzjUZgKJiE",
+	"I1tnkXQjyPM3s2zSJr/sb9OL6QXZU1eoWCWyy+zb6cX0WypVmCu8Pc5zJiUJSz+W6G1OXuT1R/5Jdd9V",
+	"WkMbDSvR+drsw7YlftAGCqa4pEREcrPaFdqIX4M1qOsAgzmKFXJYGF36Ra9n319BZfRKcG94DwoSd9Ni",
+	"IjYsLfacqXFvKbXNW8O4h8nVzdsfiKZDr/AdVMkEp5G9o8UhLXr1fnvxzRCwXuCkd7B1nqO1i1pmk6xA",
+	"xmPdK3UA8XC/QS4M+dg+Tshfvru4CD6nHKrgzvjFnVeShUC0Z/dkL88h8QCnfKpBqBWTggf7agNBbfeT",
+	"7O8PR3+mHMU/CTdoVmggtMbdIJNdfrij0FWWzGy2OSavYUvCbEaYROViiMju6IzzWAJ0nGA7xjgjcIUe",
+	"sAstOZKYps5dbTDVEWzFhGRzib3ete9NsXa60soZLSWats8eetcYJitq2LuG7zP6hmJFbLQI6BVbCuXJ",
+	"Ey9NrquFcqNt4W6iN+LXfYRfDZs7qNAzgEeR3nadbwbgYVUlo9nOf7F6C0L72sORYcYIxuKSjkfKDZho",
+	"eT7NHtajZtFrTGwltrDcT5UfstSrfDTIeHZ338P6C6pedyIwIT+B/I4qBm1HYH5lkDkE1pTEKLFE5UAo",
+	"iNnGpybKjKlypggQ3h2B9pCrWsBH4f+p+ebBjD3Spt33CxeK4vePCLexJmkP3oJpKUN2csEfA2xrIxxu",
+	"oy0YERgoXCekjMKMIiummdtxsbVF8GC2tm+sNoReM+vrhdrm6ctm4vVnzH20mDuct45A8/m2xbWxbdQl",
+	"l0ix+KtD5D5wdQDcQjZAuPATtsP4pfaEFO4r+LmuQ0xuBx5Uhl+X0OpqiFo/3+ohNoz3skc01NgUccRO",
+	"YUUSp2egjoV+z6g1mgKLLpvd7KdJzGhRqZeBmVGDzpRwwjd6TXvSb2QWUq+HtnuB7id/7jE9wNtYw1P2",
+	"7DVAYZbn6m6N+rB9waGaWUYh9hbMUi917fY1jT+FFccoIywNSEKOfAJJlGbwV+gSIcbhk5QB1Ooe7JQe",
+	"o1OxoVPBg50KVVO1pY4CrQ323qv7NDHYCeAbx4yzfnw6nC04Zj+B7qdPsILjJMw1pFgh1BX3DtCGscro",
+	"pUFrobbU3cc27EZwhOsVxRN4enNz/Wx6q2YO1kJKyKW2IannWqnQaLejk4UgHaXpBimeCZXmBg3fFMmm",
+	"t2pXdn+ZNHFUGl8IiW9YDKa7Ovrh4Ji2eRSlPs+i9J93Q/lrMNeGj86Lx9kICedV+LpzCiMN3fYEHy22",
+	"LDzGyuFE7/GOZMkz6wwyP7TGL6ys/KzJv7lM9rpVRPMS/qtrMwqyGLFB2FSpfa6xxmDKE5zpuUeGULWu",
+	"LQS+yArBtc4stSaeMzuFa5YX4UeEX4AUuLVObYy9BKbgZ7/oZ3Bs6bsZBj8T+/7BNIzvukv6n/+IY+Ig",
+	"EPL3GtbMgudkvonwIObCGDGcHA7qc0W1bu5qJr35blXEVrJS2O7VKpxFuQjb5whMrtnGAqpc81AIz5nF",
+	"f3w38cIIZyFUIcCxQsVt8nX6i1xvKrLEj2jwCUUJGT9tV9pa4aujZpn1hwYfNoE3Tk7qGQt07OWtgjPY",
+	"BggABIwwCOZtP54Hlx9T2cw9sVBqz45DFb4GbY111TJF1liKPFXagSdoUDIXvh95aVMdF1X4rMuoD8tj",
+	"bHqb9o3u13qN1xTckZN1hI16YtJqUKQLKTdQIlM2HBKqP4/ZZDwfEzkw6ykDiC4pBgvmmAzkpl1mU/Dt",
+	"8UuxMRCKoLJpOiX1miRZCJTcXsJtZh3/qGt3m03iDzQm/DBoa+luM3iqq/Bt+Bk99u87zyK7cAbxqDii",
+	"9icBM7ilcPyCee2o1H5CfssUZ4ZDuy8+CIoNOrIe+5QmVig305ZiYNFvTMQYJ+ivizjab+nG71V2Qi8N",
+	"pr3x6lHX+XopxvtOogiezNYWpjZd6/gCuDYKeYJwy8NT4YFu0EcGpjbPpjDzjygdrnW0CwnSkhQql7Uv",
+	"fVyQirkGSiMC8uiXwjbQonWS2RgQm1zldRvibqduumJ5gWex0RhpLDXkLC8IRMKGDxnRET3JeGi2/y7D",
+	"VZP1hwSe85Ww0btyKXy40fAJsdouGKhpOoISpbGzd/7NWOp8OXt53cTujgwk3iDzTQ+WixwXrJbuwVqw",
+	"NM0e5L/3Cr9UIemP1pEntcBLdL0bCM2Yz596nmYIQYMSHQ7r+vTBuG1R+1fwHmmkN34r8Xee6u24bDhi",
+	"teYuYLjo+H9tkk8b7V15hiMymqlSpyFpHt3dTw6MQ1gahCFvSox2TuUbgZRfqMZ2SBIO2+oh5Do30Y4r",
+	"/Dt3CA58M/xz+vdw079jPOUFOmi85Q80Wjp5tDgA+BReJ3DXsQ1uYQjt12inQSu5AQrOWqG/cjgddzgK",
+	"0rUlNwnXIHZNXt6nNY9o3+bezYhu/SxDWAi3Q0Co2Gb96+b1K3relE7NMKCR6mGN7AtEVruCqHJhqR7l",
+	"VOvFwvO7iwt6Y0PP6Ir2wtkDf70WJ8+Ego5smAuRaggoOaPwd2g81Ln9ePh7S14bQ+Kvdt+MPDShjpcq",
+	"H31EvX3tc9Sr4zwrifOHHVP7zlZssTs2rT4lLk22s/skY7wUKgSsePTgNkoyr+32z50r9TEjNbXi5PgT",
+	"2nA4TMZHHzQyX2pPa7/VDI/7oTakRdDtsZSgl6jQMNn9XNOeF/R+f3f/vwAAAP//sCo7SiQzAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/webserver/api.gen.go
+++ b/internal/webserver/api.gen.go
@@ -29,12 +29,12 @@ const (
 
 // Defines values for TransferItemStatus.
 const (
-	Cancelled    TransferItemStatus = "cancelled"
-	Failed       TransferItemStatus = "failed"
-	Finished     TransferItemStatus = "finished"
-	InvalidState TransferItemStatus = "invalid state"
-	Transferring TransferItemStatus = "transferring"
-	Waiting      TransferItemStatus = "waiting"
+	Cancelled     TransferItemStatus = "cancelled"
+	Failed        TransferItemStatus = "failed"
+	Finished      TransferItemStatus = "finished"
+	InvalidStatus TransferItemStatus = "invalid status"
+	Transferring  TransferItemStatus = "transferring"
+	Waiting       TransferItemStatus = "waiting"
 )
 
 // DeleteTransferRequest defines model for DeleteTransferRequest.
@@ -1336,45 +1336,45 @@ var swaggerSpec = []string{
 	"PI7hAfE32rYxcUdipNBAa0Z8oBs4IgMxcI0mm9qieac/4YgYtDVoDhytgIU2QHFILUErmGPB5CLRoHMO",
 	"GqRhu0v37pAOTk23pIId6RauGDFO3HJwGiwqDuSHPkPBnOWf6LEXSJyenGmbEp/rTk3SlinRCu2rX/R8",
 	"+rW5uxeRBhqabxzadylYDiNgeB+P8ATHVi2E3HtKeH/olN1VQ9fxUdUlib1mgnCWtQo34edCKGELX/Qs",
-	"mAjFXbfQE2rFpOAeAN2SY5cFj9Z+w+WYGd5bNDO10CNxsWRCjgqNXyph0H5k3r8X2pT0H1UZeOaED8qD",
-	"PQtWCrn5uDPoL8UK1e7XUi+XyD8K1Xk711oiU/R6577KYDDtR3LbPcs0YWH0ndEST6zgbB30e9BKrVhD",
-	"29A5mNdGuM0NpbhU2+pPAp/XrvAskfOGR1nSQtYPaKwS/0bK8fcEsWDovvO/Revg+ZuZj5K5LstaUegU",
-	"PlK6NWKo0GYxGcD7mU/rzW+KPRSNLJqVyHEKFE22HnbORQtr4Qp/5vXLs5tcXFHzkzbfKtpO7DAp9dr2",
-	"G6VY906A1U6XzIl8tNj0ZUcIpClCfq7RCAwFlXBk6yySbgR5/maWTdrkmP1tejG9IHvqChWrRHaZfTu9",
-	"mH5LpQxzhbfHec6kJGHpxxK9zcmLvP7IUakuvEpraKNhJTpfu33YtsQP2kDBFJeUqEhuVrtCG/FrsAZ1",
-	"JWAwR7FCDgujS7/o9ez7K6iMXgnuDe9BQeJuWkzEhqbFnjM17i21tnlrGPcwubp5+wPRdOgVvoNqCGWn",
-	"kL2jxSFtevV+e/HNELBe4KR3sHWeo7WLWmaTrEDGY10sdQDxcL9BLgz52D5OyF++u7gIPqccquDO+MWd",
-	"V5KFQLRn92QvzyEBAKd8qyFFfm9fbWIGuJ9kf384+jPlKP5JuEGzQgOhde4Gmezywx2FrrJkZrPNMXkN",
-	"WxJmM8IkKhdDRHZHZ5zHEqHjBNsxxhmBK/SAXWjJkcQ0de5qg6nOYCsmJJtL7PW2fW+KtdWVVs5oKdG0",
-	"ffjQu8YwWVEq7xq+z+gbihWxESOgV2wplCdPvDS5rhbKjbaNu4neiF/3EX41bP6gQs8AHkV623W+GYCH",
-	"VZWMZjv/xeotCO1rH0eGHSMYi0s6Hik3YKLl+TR7WI+aRa8xsdXYwnI/VX7IUi/z0SDj2d19D+svqLrd",
-	"icCE/ATyO6oYtB2B+ZVB5hBYUzKjxBKVA6EgZhufmigzpsqaIkB4dwTaQ65qAR+F/6fmmwcz9kgbd98v",
-	"XCiK3z8i3MaaqD14C6alDNnJBX8MsK2NoGK+j7ZgRGCgcJ2QMgoziqyYZnLHxdYWwYPZ276x2xB6zSyw",
-	"F2qbpy+bidifMffRYu5wHjsCzefbFtfGtlGXXCLF4q8OkfvA1QFwC9kA4cJP4A7jl9oTUriv4Oe6DjG5",
-	"HYhQGX5dQqurIWr9/KuH2DD+yx7RUGNTxhE7hRVJnJ6BOhb6PaPWaAosumx2s58mMaNFpV4GZkYNOlPC",
-	"Cd/oNe1Jv5FZSL0e2u4Fup/8ucf0AG9jDU/Zs9cAhVmfq7s16sP2BYdqZhmF2FswS73UtdvXNP4UVhyj",
-	"jLA0IAk58gkkUZrBYKFLhBiHT1IGUKt7sFN6jE7Fhk4FD3YqVE3VljoKtDbYe6/u08RgJ4BvHDPO+vHq",
-	"cLbgmP0Eup8+wQqOkzDXkGKFUFfcO0AbxiqjlwathdpSdx/bsBvBEa5XFE/g6c3N9bPprZo5WAspIZfa",
-	"hqSea6VCo92OThaCdJSmG6R4JlSaGzR8UySb3qpd2f1l0sRRaXwhJL5hMZju6uiHg2Xa5lGU+jyL0n/+",
-	"DeWvwVwbPjpPHmcjJJxX4evPKYw0dNsTfLTYsvAYK4cTvcc7kiXPrDPI/FAbv7Cy8rMm/+Yy2etWEc1L",
-	"+K+uzSjIYsQGYVOl9rnGGoMpT3Cm5x4ZQtW6thD4IisE1zqz1Jp4zuwUrllehB8RfgFS4NY6tTH2EpiC",
-	"n/2in8Gxpe9mGPxM7PsH0zC+6y7pfx4kjomDQMjfe1gzC56T+SbCg5gLY8RwcjiozxXVurmrmfTmu1UR",
-	"W8lKYbtXq3AW5SJsnyMwuWYbC6hyzUMhPGcW//HdxAsjnIVQhQDHChW3ydfpL3K9qcgSP6LBJxQlZPz0",
-	"XWlrha+OmmXWHxp82ATeODmpZyzQsZe3Cs5gGyAAEDDCIJi3/bgeXH5MZTP3xEKpPTsOVfhatDXWVcsU",
-	"WWMp8lRpB56gQclc+L7kpU11XFThsy6jPiyPselt2je6X+s1XlNwR07WETbqiUmrQZEupNxAiUzZcEio",
-	"/jxmk/F8TOTArKcMILqkGCyYYzKQm3aZTcG3xy/FxkAogsqm6ZTUa5JkIVByewm3mXX8o67dbTaJP9CY",
-	"8MOgraW7zeCprsK342f02L/vPIvswhnEo+KI2p8EzOCWwvEL5rWjUvsJ+S1TnBkO7b74ICg26Mh67FOa",
-	"WKHcTFuKgUW/MRFjnKC/LuJov6UbP1LZCb00mPbGq0ld5+ulGO87iSJ4MltbmNp0reML4Noo5AnCLQ9P",
-	"hQe6QR8ZmNo8m8LMP6J0uNbRLiRIS1KoXNa+9HFBKuYaKI0IyKNfCttAi9ZJZmNAbHKV122Iu5266Yrl",
-	"BZ7FRmOksdSQs7wgEAkbPmRER/Qk46HZ/rsOV03WHxJ4zlfCRu/KpfDhRsMnxGq7YKCm6QhKlMbO3vk3",
-	"Y6nz5ezldRO7OzKQeIPMNz1YLnJcsFq6B2vB0jR7kP/eK/xShaQ/Wkee1AIv0fVuKDRjPn/qeZohBA1K",
-	"dDis69PH5rZF7V/Re6SR3vitxd95qrfjMuKI1Zq7guH7+P+1ST5ttHflGY7IaKZKnYakeXR3PzkwDmFp",
-	"EIa8KTHaOZVvBFJ+oRrbIUk4bKuHkOvcVDuu8O9fJtj3zfDP6d/DTf+O8ZQX6KDxlj/QaOnk0eIA4FN4",
-	"ncBdxza4hSG0X6OdBq3kBig4a4X+SuJ03OEoSNeW3CRcg9g1eXmf1jyifZt7NyO69bMMYSHcDgGhYpv1",
-	"r5vXr+h5Uzo1w4BGqoc1si8QWe0KosqFpXqUU60XC8/vLi7ojQ09oyvaC2kP/PVanDwTCjqyYS5EqiGg",
-	"5IzC36HxUOd25OHvLXltDIm/2n1z8tCEOl66fPQR9fa10FGvjvOsJM4fdkztO1uxxe7YtPqUuDTZzu6T",
-	"jPFSqBCw4tGD2yjJvLbbP3eu3MeM1NSKk+NPaMPhMBkffdDIfKk9rf1WMzzuh9qQFkG3x1KCXqJCw2T3",
-	"c017XtD7/d39/wIAAP//7w1XRUQzAAA=",
+	"mAjFXbfQE2rFpOARAB2d7TLh0epv2Byzw3uLZqYWeiQwlkzIUanxSyUM2o/MO/hCm5L+ozIDz5zwUXmw",
+	"Z8FKITcfd0b9pVih2v1a6uUS+UehOm/nWktkil7v3FcZDLb9SH67Z5kmMIy+M1riiSWcrYN+D1qpFWto",
+	"GzoH89oIt7mhHJeKW/1J4PPaFZ4l8t7wKEtayPoRjVXi30hJ/p4wFgzd9/63aB08fzPzYTLXZVkrip3C",
+	"h0q3Rgwl2ixmA3g/83m9+U3Bh8KRRbMSOU6BwsnWw865aGEtXOHPvH55dpOLK+p+0uZbRduJHSalXtt+",
+	"pxQL3wmw2umSOZGPVpu+7giRNIXIzzUagaGiEo5snUXSjSDP38yySZsds79NL6YXZE9doWKVyC6zb6cX",
+	"02+plmGu8PY4z5mUJCz9WKK3OXmR1x85KhWGV2kNbTSsROeLtw/blvhBGyiY4pIyFcnNaldoI34N1qC2",
+	"BAzmKFbIYWF06Re9nn1/BZXRK8G94T0oSNxNi4nY0bTYc6bGvbXWNm8N4x4mVzdvfyCaDr3Cd1AlE5xG",
+	"9o4Wh7zp1fvtxTdDwHqBk97B1nmO1i5qmU2yAhmPhbHUAcTD/Qa5MORj+zghf/nu4iL4nHKogjvjF3de",
+	"SRYC0Z7dk708hwwAnBKuhhT6vX21gaC2+0n294ejP1OO4p+EGzQrNBB6526QyS4/3FHoKktmNtsck9ew",
+	"JWE2I0yicjFEZHd0xnmsETpOsB1jnBG4Qg/YhZYcSUxT5642mAoNtmJCsrnEXnPb96ZYXF1p5YyWEk3b",
+	"iA+9awyTFeXyruH7jL6hWBE7MQJ6xZZCefLES5PraqHcaN+4m+iN+HUf4VfD7g8q9AzgUaS3XeebAXhY",
+	"VclotvNfrN6C0L7+cWTaMYKxuKTjkXIDJlqeT7OH9ahZ9BoTe40tLPdT5YcsNTMfDTKe3d33sP6Cytud",
+	"CEzITyC/o4pB2xGYXxlkDoE1NTNKLFE5EApitvGpiTJjKq0pAoR3R6A95KoW8FH4f2q+eTBjj/Rx9/3C",
+	"haL4/SPCbayL2oO3YFrKkJ1c8McA29oIh9toC0YEBgrXCSmjMKPIimkod1xsbRE8GL7tm7sNodcMA3uh",
+	"tnn6shmJ/RlzHy3mDgeyI9B8vm1xbWwbdcklUiz+6hC5D1wdALeQDRAu/AjuMH6pPSGF+wp+rusQk9uJ",
+	"CJXh1yW0uhqi1g/AeogN87/sEQ01NmYcsVNYkcTpGahjod8zao2mwKLLZjf7aRIzWlTqZWBm1KAzJZzw",
+	"jV7TnvQbmYXU66HtXqD7yZ97TA/wNtbwlD17DVAY9rm6W6M+bF9wqGaWUYi9BbPUS127fU3jT2HFMcoI",
+	"SwOSkCOfQBKlmQwWukSIcfgkZQC1ugc7pcfoVGzoVPBgp0LVVG2po0Brg7336j5NDHYC+MYx46yfrw5n",
+	"C47ZT6D76ROs4DgJcw0pVgh1xb0DtGGsMnpp0FqoLXX3sQ27ERzhekXxBJ7e3Fw/m96qmYO1kBJyqW1I",
+	"6rlWKjTa7ehkIUhHabpBimdCpblBwzdFsumt2pXdXyZNHJXGF0LiGxaD6a6OfjhZpm0eRanPsyj9999Q",
+	"/hrMteGjA+VxNkLCeRU+/5zCSEO3PcFHiy0Lj7FyONF7vCNZ8sw6g8xPtfELKys/a/JvLpO9bhXRvIT/",
+	"6tqMgixGbBA2VWqfa6wxmPIEZ3rukSFUrWsLgS+yQnCtM0utiefMTuGa5UX4EeEXIAVurVMbYy+BKfjZ",
+	"L/oZHFv6bobBz8S+fzAN47vukv73QeKYOAiE/MWHNbPgOZlvIjyIuTBGDCeHg/pcUa2bu5pJb75bFbGV",
+	"rBS2e7UKZ1EuwvY5ApNrtrGAKtc8FMJzZvEf3028MMJZCFUIcKxQcZt8nf4i15uKLPEjGnxCUULGb9+V",
+	"tlb46qhZZv2hwYdN4I2Tk3rGAh17eavgDLYBAgABIwyCeduv68Hlx1Q2c08slNqz41CFz0VbY121TJE1",
+	"liJPlXbgCRqUzIUPTF7aVMdFFT7rMurD8hib3qZ9o/u1XuM1BXfkZB1ho56YtBoU6ULKDZTIlA2HhOrP",
+	"YzYZz8dEDsx6ygCiS4rBgjkmA7lpl9kUfHv8UmwMhCKobJpOSb0mSRYCJbeXcJtZxz/q2t1mk/gDjQk/",
+	"DNpautsMnuoqfDx+Ro/9+86zyC6cQTwqjqj9ScAMbikcv2BeOyq1n5DfMsWZ4dDuiw+CYoOOrMc+pYkV",
+	"ys20pRhY9BsTMcYJ+usijvZbuvErlZ3QS4Npb7yb1HW+XorxvpMogieztYWpTdc6vgCujUKeINzy8FR4",
+	"oBv0kYGpzbMpzPwjSodrHe1CgrQkhcpl7UsfF6RiroHSiIA8+qWwDbRonWQ2BsQmV3ndhrjbqZuuWF7g",
+	"WWw0RhpLDTnLCwKRsOFDRnRETzIemu2/7HDVZP0hged8JWz0rlwKH240fEKstgsGapqOoERp7OydfzOW",
+	"Ol/OXl43sbsjA4k3yHzTg+UixwWrpXuwFixNswf5773CL1VI+qN15Ekt8BJd74pCM+bzp56nGULQoESH",
+	"w7o+fW1uW9T+Hb1HGumNX1v8nad6O24jjlituSwYPpD/X5vk00Z7V57hiIxmqtRpSJpHd/eTA+MQlgZh",
+	"yJsSo51T+UYg5ReqsR2ShMO2egi5zlW14wr//mWCfd8M/5z+Pdz07xhPeYEOGm/5A42WTh4tDgA+hdcJ",
+	"3HVsg1sYQvs12mnQSm6AgrNW6O8kTscdjoJ0bclNwjWIXZOX92nNI9q3uXczols/yxAWwu0QECq2Wf+6",
+	"ef2KnjelUzMMaKR6WCP7ApHVriCqXFiqRznVerHw/O7igt7Y0DO6or2R9sBfr8XJM6GgIxvmQqQaAkrO",
+	"KPwdGg91rkce/t6S18aQ+KvdVycPTajjrctHH1Fv3wsd9eo4z0ri/GHH1L6zFVvsjk2rT4lLk+3sPskY",
+	"L4UKASsePbiNksxru/1z5859zEhNrTg5/oQ2HA6T8dEHjcyX2tPabzXD436oDWkRdHssJeglKjRMdj/X",
+	"tOcFvd/f3f8vAAD//4c24EdFMwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/webserver/transfer.go
+++ b/internal/webserver/transfer.go
@@ -40,8 +40,15 @@ func (i *IngestorWebServerImplemenation) TransferControllerGetTransfer(ctx conte
 		}
 		transferItems := []TransferItem{
 			{
-				Status:     &status.StatusMessage,
-				TransferId: &id,
+				TransferId:       id,
+				Status:           &status.StatusMessage,
+				Started:          &status.Started,
+				Finished:         &status.Finished,
+				Failed:           &status.Failed,
+				BytesTransferred: &status.BytesTransferred,
+				BytesTotal:       &status.BytesTotal,
+				FilesTransferred: &status.FilesTransferred,
+				FilesTotal:       &status.FilesTotal,
 			},
 		}
 
@@ -71,8 +78,11 @@ func (i *IngestorWebServerImplemenation) TransferControllerGetTransfer(ctx conte
 	for i, status := range statuses {
 		idString := ids[i].String()
 		transferItems = append(transferItems, TransferItem{
-			Status:     &status.StatusMessage,
-			TransferId: &idString,
+			TransferId: idString,
+			Status:     getPointerOrNil(status.StatusMessage),
+			Started:    getPointerOrNil(status.Started),
+			Finished:   getPointerOrNil(status.Finished),
+			Failed:     getPointerOrNil(status.Failed),
 		})
 	}
 
@@ -80,4 +90,13 @@ func (i *IngestorWebServerImplemenation) TransferControllerGetTransfer(ctx conte
 		Total:     &resultNo,
 		Transfers: &transferItems,
 	}, nil
+}
+
+func getPointerOrNil[T comparable](v T) *T {
+	var a T
+	if a == v {
+		return nil
+	} else {
+		return &v
+	}
 }

--- a/internal/webserver/transfer.go
+++ b/internal/webserver/transfer.go
@@ -109,6 +109,6 @@ func statusToDto(s task.Status) TransferItemStatus {
 	case task.Cancelled:
 		return Cancelled
 	default:
-		return InvalidState
+		return InvalidStatus
 	}
 }


### PR DESCRIPTION
This adds a more descriptive response to the `GET /transfer` endpoint, which *can* include the following details:
 - transfer id
 - bytes transferred so far
 - total amount of bytes of the transfer
 - files transferred
 - total files of the transfer
 - status of the transfer: 
   - 'waiting' 
   - 'transferring'
   - 'finished'
   - 'failed'
   - 'cancelled' 
   - 'invalid status' (it's only a fail-safe)
 - message: used for describing a few extra details or the reason of failure

Points that could still be discussed:
 - Should there be any other details?
 - Which details should be included when requesting a list?

Note: Requesting an individual transfer will include every statistic listed above