### PR TITLE
fix oob issue in file browser pagination

### DIFF
--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -97,7 +97,11 @@ func (i *IngestorWebServerImplemenation) DatasetControllerBrowseFilesystem(ctx c
 		return nil, err
 	}
 
-	folders = folders[0 : min(end, folderCounter)-start]
+	if folderCounter >= start {
+		folders = folders[0 : min(end, folderCounter)-start]
+	} else {
+		folders = []FolderNode{}
+	}
 
 	return DatasetControllerBrowseFilesystem200JSONResponse{
 		Folders: folders,


### PR DESCRIPTION
Fixes a small OOB issue in the pagination of the file browser, which is triggered when the user asks for a higher page than available.