### PR TITLE
implement subpools for all subcomponents

### DIFF
--- a/internal/s3upload/httpuploader.go
+++ b/internal/s3upload/httpuploader.go
@@ -36,6 +36,18 @@ type HttpUploader struct {
 var instance *HttpUploader
 var once sync.Once
 
+func InitHttpUploaderWithPool(pool pond.Pool) {
+	once.Do(func() {
+		retryClient := retryablehttp.NewClient()
+		retryClient.RetryMax = 10
+		retryClient.Backoff = retryablehttp.DefaultBackoff
+		retryClient.Logger = log()
+
+		standardClient := retryClient.StandardClient()
+		instance = &HttpUploader{Pool: pool, Client: standardClient}
+	})
+}
+
 func GetHttpUploader(poolSize int) *HttpUploader {
 	once.Do(func() {
 		retryClient := retryablehttp.NewClient()

--- a/internal/webserver/api.go
+++ b/internal/webserver/api.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/SwissOpenEM/Ingestor/internal/core"
-	"github.com/SwissOpenEM/Ingestor/internal/metadataextractor"
 	"github.com/SwissOpenEM/Ingestor/internal/webserver/metadatatasks"
 	"github.com/SwissOpenEM/Ingestor/internal/webserver/wsconfig"
 	"github.com/SwissOpenEM/globus"
@@ -20,95 +19,91 @@ import (
 var _ StrictServerInterface = (*IngestorWebServerImplemenation)(nil)
 
 type IngestorWebServerImplemenation struct {
-	version          string
-	taskQueue        *core.TaskQueue
-	metp             *metadatatasks.MetadataExtractionTaskPool
-	extractorHandler *metadataextractor.ExtractorHandler
-	oauth2Config     *oauth2.Config
-	globusAuthConf   *oauth2.Config
-	oidcProvider     *oidc.Provider
-	oidcVerifier     *oidc.IDTokenVerifier
-	jwtKeyfunc       jwt.Keyfunc
-	jwtSignMethods   []string
-	sessionDuration  uint
-	scopeToRoleMap   map[string]string
-	pathConfig       wsconfig.PathsConf
-	frontend         struct {
+	version         string
+	taskQueue       *core.TaskQueue
+	metadataExtPool *metadatatasks.MetadataExtractionTaskPool
+	oauth2Config    *oauth2.Config
+	globusAuthConf  *oauth2.Config
+	oidcProvider    *oidc.Provider
+	oidcVerifier    *oidc.IDTokenVerifier
+	jwtKeyfunc      jwt.Keyfunc
+	jwtSignMethods  []string
+	sessionDuration uint
+	scopeToRoleMap  map[string]string
+	pathConfig      wsconfig.PathsConf
+	frontend        struct {
 		origin       string
 		redirectPath string
 	}
 }
 
-func NewIngestorWebServer(version string, tq *core.TaskQueue, eh *metadataextractor.ExtractorHandler, ws wsconfig.WebServerConfig) (*IngestorWebServerImplemenation, error) {
-	oidcProvider, err := oidc.NewProvider(context.Background(), ws.IssuerURL)
+func NewIngestorWebServer(version string, transferQueue *core.TaskQueue, metadataExtPool *metadatatasks.MetadataExtractionTaskPool, serverConf wsconfig.WebServerConfig) (*IngestorWebServerImplemenation, error) {
+	oidcProvider, err := oidc.NewProvider(context.Background(), serverConf.IssuerURL)
 	if err != nil {
 		fmt.Println("Warning: OIDC discovery mechanism failed. Falling back to manual OIDC config")
 		// fallback provider (this could also be replaced with an error)
 		a := &oidc.ProviderConfig{
-			IssuerURL:   ws.IssuerURL,
-			AuthURL:     ws.AuthURL,
-			TokenURL:    ws.TokenURL,
-			UserInfoURL: ws.UserInfoURL,
-			Algorithms:  ws.Algorithms,
+			IssuerURL:   serverConf.IssuerURL,
+			AuthURL:     serverConf.AuthURL,
+			TokenURL:    serverConf.TokenURL,
+			UserInfoURL: serverConf.UserInfoURL,
+			Algorithms:  serverConf.Algorithms,
 		}
 		oidcProvider = a.NewProvider(context.Background())
 	}
-	oidcVerifier := oidcProvider.Verifier(&oidc.Config{ClientID: ws.OAuth2Conf.ClientID})
+	oidcVerifier := oidcProvider.Verifier(&oidc.Config{ClientID: serverConf.OAuth2Conf.ClientID})
 	oauthConf := oauth2.Config{
-		ClientID:     ws.OAuth2Conf.ClientID,
-		ClientSecret: ws.ClientSecret,
+		ClientID:     serverConf.OAuth2Conf.ClientID,
+		ClientSecret: serverConf.ClientSecret,
 		Endpoint:     oidcProvider.Endpoint(),
-		RedirectURL:  ws.RedirectURL,
-		Scopes:       append([]string{oidc.ScopeOpenID}, ws.Scopes...),
+		RedirectURL:  serverConf.RedirectURL,
+		Scopes:       append([]string{oidc.ScopeOpenID}, serverConf.Scopes...),
 	}
 
-	keyfunc, err := initKeyfunc(ws.JWTConf)
+	keyfunc, err := initKeyfunc(serverConf.JWTConf)
 	if err != nil {
 		return nil, err
 	}
 
 	var signMethods []string
-	if ws.UseJWKS {
-		signMethods = ws.JwksSignatureMethods
+	if serverConf.UseJWKS {
+		signMethods = serverConf.JwksSignatureMethods
 	} else {
-		signMethods = []string{ws.JWTConf.KeySignMethod}
+		signMethods = []string{serverConf.JWTConf.KeySignMethod}
 	}
 
-	scopeToRoleMap, err := createScopeToRoleMap(ws.RBACConf)
+	scopeToRoleMap, err := createScopeToRoleMap(serverConf.RBACConf)
 	if err != nil {
 		return nil, err
 	}
 
-	metadataTaskPool := metadatatasks.NewTaskPool(ws.QueueSize, ws.ConcurrencyLimit, eh)
-
 	globusAuthConf := globus.AuthGenerateOauthClientConfig(
 		context.Background(),
-		tq.Config.Transfer.Globus.ClientID,
-		tq.Config.Transfer.Globus.ClientSecret,
-		tq.Config.Transfer.Globus.RedirectURL,
-		tq.Config.Transfer.Globus.Scopes,
+		transferQueue.Config.Transfer.Globus.ClientID,
+		transferQueue.Config.Transfer.Globus.ClientSecret,
+		transferQueue.Config.Transfer.Globus.RedirectURL,
+		transferQueue.Config.Transfer.Globus.Scopes,
 	)
 
 	return &IngestorWebServerImplemenation{
-		version:          version,
-		taskQueue:        tq,
-		extractorHandler: eh,
-		oauth2Config:     &oauthConf,
-		globusAuthConf:   &globusAuthConf,
-		oidcProvider:     oidcProvider,
-		oidcVerifier:     oidcVerifier,
-		jwtKeyfunc:       keyfunc,
-		jwtSignMethods:   signMethods,
-		scopeToRoleMap:   scopeToRoleMap,
-		sessionDuration:  ws.SessionDuration,
-		pathConfig:       ws.PathsConf,
-		metp:             metadataTaskPool,
+		version:         version,
+		taskQueue:       transferQueue,
+		oauth2Config:    &oauthConf,
+		globusAuthConf:  &globusAuthConf,
+		oidcProvider:    oidcProvider,
+		oidcVerifier:    oidcVerifier,
+		jwtKeyfunc:      keyfunc,
+		jwtSignMethods:  signMethods,
+		scopeToRoleMap:  scopeToRoleMap,
+		sessionDuration: serverConf.SessionDuration,
+		pathConfig:      serverConf.PathsConf,
+		metadataExtPool: metadataExtPool,
 		frontend: struct {
 			origin       string
 			redirectPath string
 		}{
-			origin:       ws.FrontendConf.Origin,
-			redirectPath: ws.FrontendConf.RedirectPath,
+			origin:       serverConf.FrontendConf.Origin,
+			redirectPath: serverConf.FrontendConf.RedirectPath,
 		},
 	}, nil
 }

--- a/internal/webserver/extractor.go
+++ b/internal/webserver/extractor.go
@@ -6,7 +6,7 @@ import (
 
 func (i *IngestorWebServerImplemenation) ExtractorControllerGetExtractorMethods(ctx context.Context, request ExtractorControllerGetExtractorMethodsRequestObject) (ExtractorControllerGetExtractorMethodsResponseObject, error) {
 	// get methods
-	methods := i.extractorHandler.AvailableMethods()
+	methods := i.metadataExtPool.GetHandler().AvailableMethods()
 	total := len(methods)
 
 	// get indices

--- a/internal/webserver/metadata.go
+++ b/internal/webserver/metadata.go
@@ -103,7 +103,7 @@ func (r ResponseWriter) VisitExtractMetadataResponse(writer http.ResponseWriter)
 }
 
 func (i *IngestorWebServerImplemenation) ExtractMetadata(ctx context.Context, request ExtractMetadataRequestObject) (ExtractMetadataResponseObject, error) {
-	return ResponseWriter{ctx: ctx, metadataTaskPool: i.metp, req: request, collectionLocation: i.pathConfig.CollectionLocation}, nil
+	return ResponseWriter{ctx: ctx, metadataTaskPool: i.metadataExtPool, req: request, collectionLocation: i.pathConfig.CollectionLocation}, nil
 }
 
 type progressDto struct {

--- a/internal/webserver/metadatatasks/taskpool.go
+++ b/internal/webserver/metadatatasks/taskpool.go
@@ -34,13 +34,20 @@ func (p *MetadataExtractionTaskPool) NewTask(ctx context.Context, datasetPath st
 	return &progress, nil
 }
 
+func (p *MetadataExtractionTaskPool) GetHandler() *metadataextractor.ExtractorHandler {
+	return p.extractionHandler
+}
+
 func NewTaskPool(queueSize int, maxConcurrency int, handler *metadataextractor.ExtractorHandler) *MetadataExtractionTaskPool {
 	pondPool := pond.NewPool(int(maxConcurrency), pond.WithQueueSize(int(queueSize)))
-	pool := MetadataExtractionTaskPool{
-		pool:              pondPool,
+	return NewTaskPoolFromPool(handler, pondPool)
+}
+
+func NewTaskPoolFromPool(handler *metadataextractor.ExtractorHandler, pool pond.Pool) *MetadataExtractionTaskPool {
+	taskPool := MetadataExtractionTaskPool{
+		pool:              pool,
 		waitGroup:         sync.WaitGroup{},
 		extractionHandler: handler,
 	}
-
-	return &pool
+	return &taskPool
 }


### PR DESCRIPTION
This PR implements pond subpools for all components relying on workers. This was mostly tested in terms of whether it works, but the benefits of this change are not clear.