### PR TITLE
s3Upload fix: ignore directories when iterating files to upload

### DIFF
--- a/internal/s3upload/s3upload.go
+++ b/internal/s3upload/s3upload.go
@@ -79,8 +79,11 @@ func UploadS3(ctx context.Context, datasetPID string, datasetSourceFolder string
 
 	s3Objects := S3Objects{}
 	for _, f := range fileList {
-		s, _ := os.Stat(path.Join(datasetSourceFolder, f.Path))
-		s3Objects.TotalBytes += s.Size()
+		info, _ := os.Stat(path.Join(datasetSourceFolder, f.Path))
+		if info.IsDir() {
+			continue
+		}
+		s3Objects.TotalBytes += info.Size()
 		s3Objects.Files = append(s3Objects.Files, path.Join(datasetSourceFolder, f.Path))
 		s3Objects.ObjectNames = append(s3Objects.ObjectNames, "openem-network/datasets/"+datasetPID+"/raw_files/"+f.Path)
 	}


### PR DESCRIPTION
S3 upload should reproduce the folder structure of the selected dataset if it has a nested structure