### PR TITLE
Feature/multiple collection locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - (CONFIG) Transfer.Globus.DestinationPrefixPath is removed because DestinationTemplate replaces it in functionality
 
 ## [PR #126] (2025-04-29)
+### Added
+ - (Config) Transfer.ExtGlobus.CollectionRootPath is the path at which the Globus Collection is rooted. This value is used to convert absolute paths to Globus paths
 ### Changed
  - (Config) Webserver.Paths.CollectionLocation is now WebServer.Paths.CollectionLocations (plural), and its contents are now a map that maps collection location names (strings) to paths (strings).
  - (Code) the API now expects dataset paths to have their first path node to contain the collection location 'name'.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - (CODE) Some refactoring, particularly there's now separate S3 and Globus add task functions
 ### Removed
  - (CONFIG) Transfer.Globus.DestinationPrefixPath is removed because DestinationTemplate replaces it in functionality
+
+## [PR #126] (2025-04-29)
+### Changed
+ - (Config) Webserver.Paths.CollectionLocation is now WebServer.Paths.CollectionLocations (plural), and its contents are now a map that maps collection location names (strings) to paths (strings).
+ - (Code) the API now expects dataset paths to have their first path node to contain the collection location 'name'.  
+
+A recommendation is to have the name of the collection's root folder to be the same as its "name" in the map. For example,  "example_collection" is  mapped to "/some/location/example_collection".

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -67,43 +67,6 @@ paths:
                   type: string
 
   /dataset:
-    get:
-      tags:
-        - dataset
-      summary: Get the available datasets.
-      security:
-        - cookieAuth:
-          - ingestor_read
-      description: Retrieve the folder structure of the available datasets.
-      operationId: DatasetController_getDataset
-      parameters:
-        - name: page
-          in: query
-          required: false
-          schema:
-            type: integer
-            format: uint
-            description: Page number for pagination.
-        - name: pageSize
-          in: query
-          required: false
-          schema:
-            type: integer
-            format: uint
-            description: Number of transfers per page.
-      responses:
-        "200":
-          description: Dataset successfully retrieved.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/GetDatasetResponse"
-        "400":
-          description: Invalid request
-          content:
-            text/plain:
-              schema:
-                type: string
     post:
       tags:
         - dataset
@@ -668,19 +631,6 @@ components:
         - name
         - schema
       description: a method item describes the method's name and schema
-    GetDatasetResponse:
-      type: object
-      properties:
-        datasets:
-          type: array
-          items:
-            type: string
-        total:
-          type: integer
-          description: Total number of datasets.
-      required:
-        - datasets
-        - total
     GetBrowseDatasetResponse:
       type: object
       properties:

--- a/configs/openem-ingestor-config.yaml
+++ b/configs/openem-ingestor-config.yaml
@@ -66,7 +66,8 @@ WebServer:
       CreateModifyTasksRole: "FACILITY-ingestor-write"
       ViewTasksRole: "FACILITY-ingestor-read"
   Paths:
-    CollectionLocation: "/some/paths"
+    CollectionLocations: 
+      "path": "/some/paths"
   MetadataExtJobs:
     ConcurrencyLimit: 4
     QueueSize: 200

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -78,7 +78,7 @@ func createExpectedValidConfig(transferConfig transfertask.TransferConfig) Confi
 			},
 		},
 		PathsConf: wsconfig.PathsConf{
-			CollectionLocation: "/some/path",
+			CollectionLocations: map[string]string{"path": "/some/path"},
 		},
 		MetadataExtJobsConf: wsconfig.MetadataExtJobsConf{
 			ConcurrencyLimit: 100,

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -78,7 +78,10 @@ func createExpectedValidConfig(transferConfig transfertask.TransferConfig) Confi
 			},
 		},
 		PathsConf: wsconfig.PathsConf{
-			CollectionLocations: map[string]string{"path": "/some/path"},
+			CollectionLocations: map[string]string{
+				"path":   "/some/path",
+				"folder": "/another/folder",
+			},
 		},
 		MetadataExtJobsConf: wsconfig.MetadataExtJobsConf{
 			ConcurrencyLimit: 100,

--- a/internal/core/ingestdataset.go
+++ b/internal/core/ingestdataset.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SwissOpenEM/Ingestor/internal/globustransfer"
 	"github.com/SwissOpenEM/Ingestor/internal/s3upload"
 	"github.com/SwissOpenEM/Ingestor/internal/transfertask"
+	"github.com/SwissOpenEM/Ingestor/internal/webserver/collections"
 	"github.com/SwissOpenEM/globus"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
@@ -223,7 +224,12 @@ func TransferDataset(
 		}
 
 		// globus doesn't work with absolute folders, this library uses sourcePrefix to adapt the path to the globus' own path from a relative path
-		relativeDatasetFolder := strings.TrimPrefix(datasetFolder, config.WebServer.CollectionLocation)
+		_, _, relativeDatasetFolder, err := collections.GetPathDetails(config.WebServer.CollectionLocations, filepath.Clean(datasetFolder))
+		if err != nil {
+			return err
+		}
+		//relativeDatasetFolder := strings.TrimPrefix(datasetFolder, config.WebServer.CollectionLocation)
+
 		files := make([]globustransfer.File, len(fileList))
 		bytesTotal := 0
 		for i, file := range fileList {
@@ -250,6 +256,9 @@ func TransferDataset(
 				transferTask.UpdateProgress(&bytesTransferred, &filesTransferred)
 			},
 		)
+		if err != nil {
+			return err
+		}
 	default:
 		err = fmt.Errorf("unknown transfer method: %d", transferTask.TransferMethod)
 	}

--- a/internal/core/ingestdataset.go
+++ b/internal/core/ingestdataset.go
@@ -228,7 +228,6 @@ func TransferDataset(
 		if err != nil {
 			return err
 		}
-		//relativeDatasetFolder := strings.TrimPrefix(datasetFolder, config.WebServer.CollectionLocation)
 
 		files := make([]globustransfer.File, len(fileList))
 		bytesTotal := 0

--- a/internal/transfertask/config.go
+++ b/internal/transfertask/config.go
@@ -22,6 +22,7 @@ type GlobusTransferConfig struct {
 
 type ExtGlobusTransferConfig struct {
 	TransferServiceUrl string `string:"TransferServiceUrl" validate:"http_url"`
+	CollectionRootPath string `string:"CollectionRootPath"`
 	SrcFacility        string `string:"SourceFacility" validate:"required"`
 	DstFacility        string `string:"DestinationFacility" validate:"required"`
 }

--- a/internal/webserver/collections/funcs.go
+++ b/internal/webserver/collections/funcs.go
@@ -1,0 +1,42 @@
+package collections
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+)
+
+func GetCollectionList(collectionLocations map[string]string) []string {
+	locationKeys := make([]string, len(collectionLocations))
+	i := 0
+	for location := range collectionLocations {
+		locationKeys[i] = location
+		i++
+	}
+	sort.Strings(locationKeys)
+	return locationKeys
+}
+
+// returns: collection name, collection path, the remainder of the path
+func GetPathDetails(collectionLocations map[string]string, path string) (string, string, string, error) {
+	splitSourceFolder := filepath.SplitList(path)
+	if len(splitSourceFolder) <= 0 {
+		return "", "", "", fmt.Errorf("sourceFolder contains an invalid path")
+	}
+
+	collectionLocationPath, ok := collectionLocations[splitSourceFolder[0]]
+	if !ok {
+		return "", "", "", fmt.Errorf("sourceFolder contains an invalid path (invalid collection location)")
+	}
+
+	return splitSourceFolder[0], collectionLocationPath, filepath.Join(splitSourceFolder[1:]...), nil
+}
+
+// helper function that converts the given datasetFolder to a system absolute path using the 'collectionLocations' map
+func GetDatasetAbsolutePath(collectionLocations map[string]string, path string) (string, error) {
+	_, colPath, relPath, err := GetPathDetails(collectionLocations, path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(colPath, relPath), nil
+}

--- a/internal/webserver/collections/funcs.go
+++ b/internal/webserver/collections/funcs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 func GetCollectionList(collectionLocations map[string]string) []string {
@@ -19,7 +20,7 @@ func GetCollectionList(collectionLocations map[string]string) []string {
 
 // returns: collection name, collection path, the remainder of the path
 func GetPathDetails(collectionLocations map[string]string, path string) (string, string, string, error) {
-	splitSourceFolder := filepath.SplitList(path)
+	splitSourceFolder := strings.Split(strings.TrimPrefix(path, string(filepath.Separator)), string(filepath.Separator))
 	if len(splitSourceFolder) <= 0 {
 		return "", "", "", fmt.Errorf("sourceFolder contains an invalid path")
 	}

--- a/internal/webserver/collections/funcs_test.go
+++ b/internal/webserver/collections/funcs_test.go
@@ -1,15 +1,28 @@
 package collections
 
-import "testing"
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
 
 func TestGetDatasetAbsolutePath(t *testing.T) {
 	collectionLocations := map[string]string{
 		"path1": "/some/path1",
 		"path2": "/some/path2",
 	}
+	if runtime.GOOS == "windows" {
+		collectionLocations = map[string]string{
+			"path1": "C:\\some\\path1",
+			"path2": "C:\\some\\path2",
+		}
+	}
 
 	expectedPath := "/some/path1/sub/path/to/dataset"
-	absPath, err := GetDatasetAbsolutePath(collectionLocations, "/path1/sub/path/to/dataset")
+	if runtime.GOOS == "windows" {
+		expectedPath = "C:\\some\\path1\\sub\\path\\to\\dataset"
+	}
+	absPath, err := GetDatasetAbsolutePath(collectionLocations, filepath.Clean("/path1/sub/path/to/dataset"))
 	if err != nil {
 		t.Errorf("received error from function: %s", err.Error())
 		return
@@ -20,7 +33,10 @@ func TestGetDatasetAbsolutePath(t *testing.T) {
 	}
 
 	expectedPath = "/some/path2/another/path/to/dataset"
-	absPath, err = GetDatasetAbsolutePath(collectionLocations, "/path2/another/path/to/dataset")
+	if runtime.GOOS == "windows" {
+		expectedPath = "C:\\some\\path2\\another\\path\\to\\dataset"
+	}
+	absPath, err = GetDatasetAbsolutePath(collectionLocations, filepath.Clean("/path2/another/path/to/dataset"))
 	if err != nil {
 		t.Errorf("received error from function: %s", err.Error())
 		return

--- a/internal/webserver/collections/funcs_test.go
+++ b/internal/webserver/collections/funcs_test.go
@@ -1,0 +1,32 @@
+package collections
+
+import "testing"
+
+func TestGetDatasetAbsolutePath(t *testing.T) {
+	collectionLocations := map[string]string{
+		"path1": "/some/path1",
+		"path2": "/some/path2",
+	}
+
+	expectedPath := "/some/path1/sub/path/to/dataset"
+	absPath, err := GetDatasetAbsolutePath(collectionLocations, "/path1/sub/path/to/dataset")
+	if err != nil {
+		t.Errorf("received error from function: %s", err.Error())
+		return
+	}
+	if absPath != expectedPath {
+		t.Errorf("path result is different from what is expected - got: '%s', want: '%s'", absPath, expectedPath)
+		return
+	}
+
+	expectedPath = "/some/path2/another/path/to/dataset"
+	absPath, err = GetDatasetAbsolutePath(collectionLocations, "/path2/another/path/to/dataset")
+	if err != nil {
+		t.Errorf("received error from function: %s", err.Error())
+		return
+	}
+	if absPath != expectedPath {
+		t.Errorf("path result is different from what is expected - got: '%s', want: '%s'", absPath, expectedPath)
+		return
+	}
+}

--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/SwissOpenEM/Ingestor/internal/core"
 	"github.com/SwissOpenEM/Ingestor/internal/extglobusservice"
@@ -153,6 +154,12 @@ func (i *IngestorWebServerImplemenation) DatasetControllerIngestDataset(ctx cont
 	folderPath, err := collections.GetDatasetAbsolutePath(i.pathConfig.CollectionLocations, cleanedSourceFolder)
 	if err != nil {
 		return DatasetControllerIngestDataset400TextResponse(err.Error()), nil
+	}
+
+	// adapt source folder attribute to Globus collection path **only if** using external Globus transfer request service
+	//   as the service uses it to find the dataset's folder (due to security concerns)
+	if i.taskQueue.GetTransferMethod() == transfertask.TransferExtGlobus {
+		metadata["sourceFolder"] = strings.TrimPrefix(folderPath, i.taskQueue.Config.Transfer.ExtGlobus.CollectionRootPath)
 	}
 
 	ownerGroup, ok := metadata["ownerGroup"].(string)

--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
-	"slices"
 
 	"github.com/SwissOpenEM/Ingestor/internal/core"
 	"github.com/SwissOpenEM/Ingestor/internal/extglobusservice"
 	"github.com/SwissOpenEM/Ingestor/internal/s3upload"
 	"github.com/SwissOpenEM/Ingestor/internal/transfertask"
+	"github.com/SwissOpenEM/Ingestor/internal/webserver/collections"
 	"github.com/SwissOpenEM/Ingestor/internal/webserver/globusauth"
 	"github.com/google/uuid"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
@@ -42,9 +43,33 @@ func (i *IngestorWebServerImplemenation) DatasetControllerBrowseFilesystem(ctx c
 		return hasFiles, hasDirs
 	}
 
-	// get absolute path in os format
-	// Clean = remove relative paths and convert / to \ under Windows (consistent pathstrings across OS's)
-	absPath := filepath.Join(i.pathConfig.CollectionLocation, filepath.Clean(request.Params.Path))
+	// if we're at the root, return list of collection locations
+	if path.Clean(request.Params.Path) == "/" {
+		collections := collections.GetCollectionList(i.pathConfig.CollectionLocations)
+		folders := make([]FolderNode, len(collections))
+
+		for c, collection := range collections {
+			path := i.pathConfig.CollectionLocations[collection]
+			_, hasChildren := folderHasFilesOrSubFolders(path)
+			folders[c] = FolderNode{
+				Children:        hasChildren,
+				Name:            collection,
+				Path:            "/" + collection,
+				ProbablyDataset: false,
+			}
+		}
+
+		return DatasetControllerBrowseFilesystem200JSONResponse{
+			Folders: folders,
+			Total:   uint(len(collections)),
+		}, nil
+	}
+
+	collectionName, collectionPath, relPath, err := collections.GetPathDetails(i.pathConfig.CollectionLocations, filepath.Clean(request.Params.Path))
+	if err != nil {
+		return DatasetControllerBrowseFilesystem400TextResponse(err.Error()), nil
+	}
+	absPath := filepath.Join(collectionPath, relPath)
 
 	// check if path is dir
 	folder, err := os.Stat(absPath)
@@ -75,17 +100,17 @@ func (i *IngestorWebServerImplemenation) DatasetControllerBrowseFilesystem(ctx c
 	folders := make([]FolderNode, pageSize)
 
 	// flat directory walk to put a section of folders into the 'folders' slice
-	err = filepath.WalkDir(absPath, func(path string, d os.DirEntry, err error) error {
+	err = filepath.WalkDir(absPath, func(currPath string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil // skip errored elements
 		}
-		if d.IsDir() && path != absPath {
+		if d.IsDir() && currPath != absPath {
 			if folderCounter >= start && folderCounter < end {
-				hasFiles, hasChildren := folderHasFilesOrSubFolders(path)
-				relativePath, _ := filepath.Rel(i.pathConfig.CollectionLocation, path)
+				hasFiles, hasChildren := folderHasFilesOrSubFolders(currPath)
+				relativePath, _ := filepath.Rel(collectionPath, currPath)
 
 				folders[folderCounter-start].Name = d.Name()
-				folders[folderCounter-start].Path = "/" + relativePath
+				folders[folderCounter-start].Path = "/" + collectionName + "/" + filepath.ToSlash(relativePath)
 				folders[folderCounter-start].Children = hasChildren
 				folders[folderCounter-start].ProbablyDataset = hasFiles
 			}
@@ -122,7 +147,13 @@ func (i *IngestorWebServerImplemenation) DatasetControllerIngestDataset(ctx cont
 	if !ok {
 		return DatasetControllerIngestDataset400TextResponse("sourceFolder is not present in the metadata"), nil
 	}
-	folderPath := filepath.Join(i.pathConfig.CollectionLocation, filepath.Clean(sourceFolder))
+	cleanedSourceFolder := filepath.Clean(sourceFolder)
+
+	// the sourceFolder attribute's first folder indicates the collection location 'key' (should be the collection's base directory name)
+	folderPath, err := collections.GetDatasetAbsolutePath(i.pathConfig.CollectionLocations, cleanedSourceFolder)
+	if err != nil {
+		return DatasetControllerIngestDataset400TextResponse(err.Error()), nil
+	}
 
 	ownerGroup, ok := metadata["ownerGroup"].(string)
 	if !ok {
@@ -248,40 +279,6 @@ func (i *IngestorWebServerImplemenation) addS3TransferTask(ctx context.Context, 
 	}
 	return taskId, nil
 }
-
-func (i *IngestorWebServerImplemenation) DatasetControllerGetDataset(ctx context.Context, request DatasetControllerGetDatasetRequestObject) (DatasetControllerGetDatasetResponseObject, error) {
-	files, err := os.ReadDir(i.pathConfig.CollectionLocation)
-	if err != nil {
-		return nil, err
-	}
-
-	var datasets []string
-	for _, file := range files {
-		if file.IsDir() {
-			datasets = append(datasets, file.Name())
-		}
-	}
-	slices.Sort(datasets)
-
-	page := uint(1)
-	pageSize := uint(10)
-	if request.Params.Page != nil {
-		page = max(*request.Params.Page, 1)
-	}
-	if request.Params.PageSize != nil {
-		pageSize = min(*request.Params.PageSize, 100)
-	}
-
-	return DatasetControllerGetDataset200JSONResponse{
-		Datasets: safeSubslice(datasets, (page-1)*pageSize, page*pageSize),
-		Total:    len(datasets),
-	}, nil
-}
-
-//func ptr[T any](v T) *T {
-//	var temp T = v
-//	return &temp
-//}
 
 func safeSubslice[T any](s []T, start, end uint) []T {
 	sLen := uint(len(s))

--- a/internal/webserver/dataset_test.go
+++ b/internal/webserver/dataset_test.go
@@ -1,0 +1,181 @@
+package webserver
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/SwissOpenEM/Ingestor/internal/core"
+	"github.com/SwissOpenEM/Ingestor/internal/webserver/wsconfig"
+	"github.com/google/uuid"
+)
+
+func TestDatasetControllerBrowseFilesystem_LocationList(t *testing.T) {
+	collectionLocations := map[string]string{
+		"collection1": "/one/collection1",
+		"folder":      "/another/collection2",
+	}
+
+	wsConf := wsconfig.WebServerConfig{
+		AuthConf: wsconfig.AuthConf{
+			Disable: true,
+			RBACConf: wsconfig.RBACConf{
+				AdminRole:             "none",
+				CreateModifyTasksRole: "none2",
+				ViewTasksRole:         "none3",
+			},
+		},
+		PathsConf: wsconfig.PathsConf{
+			CollectionLocations:     collectionLocations,
+			ExtractorOutputLocation: "/tmp",
+		},
+		MetadataExtJobsConf: wsconfig.MetadataExtJobsConf{
+			ConcurrencyLimit: 1,
+			QueueSize:        1,
+		},
+		OtherConf: wsconfig.OtherConf{
+			BackendAddress:             "localhost",
+			Port:                       8080,
+			LogLevel:                   "Debug",
+			DisableServiceAccountCheck: true,
+		},
+	}
+	i, err := NewIngestorWebServer("test", &core.TaskQueue{}, nil, wsConf)
+	if err != nil {
+		t.Errorf("NewIngestorWebServer error: %s", err.Error())
+		return
+	}
+
+	req := DatasetControllerBrowseFilesystemRequestObject{
+		Params: DatasetControllerBrowseFilesystemParams{
+			Path:     "/",
+			Page:     getPointerOrNil(uint(1)),
+			PageSize: getPointerOrNil(uint(10)),
+		},
+	}
+	resp, err := i.DatasetControllerBrowseFilesystem(context.Background(), req)
+	if err != nil {
+		t.Errorf("DatasetControllerBrowseFilesystem error: %s", err.Error())
+		return
+	}
+
+	resp200, ok := resp.(DatasetControllerBrowseFilesystem200JSONResponse)
+	if !ok {
+		resp400, ok := resp.(DatasetControllerBrowseFilesystem400TextResponse)
+		if !ok {
+			t.Errorf("unknown error object received")
+			return
+		}
+		t.Errorf("error returned by controller: %s", resp400)
+	}
+
+	if len(resp200.Folders) != len(collectionLocations) {
+		t.Errorf("The returned list of collection locations does not match in length the one that was set - got: %d, want: %d", len(resp200.Folders), len(collectionLocations))
+		return
+	}
+
+	mismatchedKeys := []string{}
+	for _, folder := range resp200.Folders {
+		if _, ok := collectionLocations[folder.Name]; !ok {
+			mismatchedKeys = append(mismatchedKeys, folder.Name)
+		}
+	}
+	if len(mismatchedKeys) > 0 {
+		t.Errorf("The returned list contains invalid elements: %v", mismatchedKeys)
+		return
+	}
+}
+
+func TestDatasetControllerBrowseFilesystem_ExampleListInCollection(t *testing.T) {
+	collectionLocations := map[string]string{}
+
+	testSession := uuid.New()
+	testPath := filepath.Join(os.TempDir(), testSession.String())
+	err := os.MkdirAll(testPath, 0777)
+	if err != nil {
+		t.Errorf("can't create test folder: %s", err.Error())
+		return
+	}
+
+	collectionLocations["test"] = testPath
+
+	testFolders := []string{"dataset1", "dataset2", "dataset3"}
+	for _, folder := range testFolders {
+		err = os.MkdirAll(filepath.Join(testPath, folder), 0777)
+		if err != nil {
+			t.Errorf("couldn't create %s's folder: %s", folder, err.Error())
+			return
+		}
+	}
+
+	wsConf := wsconfig.WebServerConfig{
+		AuthConf: wsconfig.AuthConf{
+			Disable: true,
+			RBACConf: wsconfig.RBACConf{
+				AdminRole:             "none",
+				CreateModifyTasksRole: "none2",
+				ViewTasksRole:         "none3",
+			},
+		},
+		PathsConf: wsconfig.PathsConf{
+			CollectionLocations:     collectionLocations,
+			ExtractorOutputLocation: "/tmp",
+		},
+		MetadataExtJobsConf: wsconfig.MetadataExtJobsConf{
+			ConcurrencyLimit: 1,
+			QueueSize:        1,
+		},
+		OtherConf: wsconfig.OtherConf{
+			BackendAddress:             "localhost",
+			Port:                       8080,
+			LogLevel:                   "Debug",
+			DisableServiceAccountCheck: true,
+		},
+	}
+	i, err := NewIngestorWebServer("test", &core.TaskQueue{}, nil, wsConf)
+	if err != nil {
+		t.Errorf("NewIngestorWebServer error: %s", err.Error())
+		return
+	}
+
+	req := DatasetControllerBrowseFilesystemRequestObject{
+		Params: DatasetControllerBrowseFilesystemParams{
+			Path:     "/test",
+			Page:     getPointerOrNil(uint(1)),
+			PageSize: getPointerOrNil(uint(10)),
+		},
+	}
+	resp, err := i.DatasetControllerBrowseFilesystem(context.Background(), req)
+	if err != nil {
+		t.Errorf("DatasetControllerBrowseFilesystem error: %s", err.Error())
+		return
+	}
+
+	resp200, ok := resp.(DatasetControllerBrowseFilesystem200JSONResponse)
+	if !ok {
+		resp400, ok := resp.(DatasetControllerBrowseFilesystem400TextResponse)
+		if !ok {
+			t.Errorf("unknown error object received")
+			return
+		}
+		t.Errorf("error returned by controller: %s", resp400)
+	}
+
+	if len(resp200.Folders) != len(testFolders) {
+		t.Errorf("The returned list of folders does not match in length the one that was set - got: %d, want: %d", len(resp200.Folders), len(testFolders))
+		return
+	}
+
+	mismatchedFolders := []string{}
+	for _, folder := range resp200.Folders {
+		if slices.Contains(testFolders, folder.Name); !ok {
+			mismatchedFolders = append(mismatchedFolders, folder.Name)
+		}
+	}
+	if len(mismatchedFolders) > 0 {
+		t.Errorf("The returned list of folders contains invalid elements: %v", mismatchedFolders)
+		return
+	}
+}

--- a/internal/webserver/wsconfig/config.go
+++ b/internal/webserver/wsconfig/config.go
@@ -52,7 +52,7 @@ type AuthConf struct {
 }
 
 type PathsConf struct {
-	CollectionLocation      string `validate:"required"`
+	CollectionLocations     map[string]string `validate:"required"`
 	ExtractorOutputLocation string
 }
 

--- a/test/testdata/valid_config_globus.yaml
+++ b/test/testdata/valid_config_globus.yaml
@@ -76,7 +76,8 @@ WebServer:
       CreateModifyTasksRole: "FACILITY-ingestor-write"
       ViewTasksRole: "FACILITY-ingestor-read"
   Paths:
-    CollectionLocation: "/some/path"
+    CollectionLocations: 
+      path: "/some/path"
   MetadataExtJobs:
     ConcurrencyLimit: 100
     QueueSize: 200

--- a/test/testdata/valid_config_globus.yaml
+++ b/test/testdata/valid_config_globus.yaml
@@ -78,6 +78,7 @@ WebServer:
   Paths:
     CollectionLocations: 
       path: "/some/path"
+      folder: "/another/folder"
   MetadataExtJobs:
     ConcurrencyLimit: 100
     QueueSize: 200

--- a/test/testdata/valid_config_s3.yaml
+++ b/test/testdata/valid_config_s3.yaml
@@ -76,6 +76,7 @@ WebServer:
   Paths:
     CollectionLocations: 
       path: "/some/path"
+      folder: "/another/folder"
   MetadataExtJobs:
     ConcurrencyLimit: 100
     QueueSize: 200

--- a/test/testdata/valid_config_s3.yaml
+++ b/test/testdata/valid_config_s3.yaml
@@ -74,7 +74,8 @@ WebServer:
       CreateModifyTasksRole: "FACILITY-ingestor-write"
       ViewTasksRole: "FACILITY-ingestor-read"
   Paths:
-    CollectionLocation: "/some/path"
+    CollectionLocations: 
+      path: "/some/path"
   MetadataExtJobs:
     ConcurrencyLimit: 100
     QueueSize: 200


### PR DESCRIPTION
This PR adds support for multiple collection locations. 

This is achieved by not modifying the base API itself, since the first folder node of the dataset path now selects the collection location to be used.