### PR TITLE
118 s3 use archiver endpoint to finalize upload and delegate archival job creation

### DIFF
--- a/internal/core/taskqueue.go
+++ b/internal/core/taskqueue.go
@@ -38,7 +38,7 @@ func (w *TaskQueue) Startup() {
 	}
 }
 
-func (w *TaskQueue) AddTransferTask(datasetId string, fileList []datasetIngestor.Datafile, taskId uuid.UUID, folderPath string, ownerGroup string, autoArchive bool, transferObjects map[string]interface{}) error {
+func (w *TaskQueue) AddTransferTask(datasetId string, fileList []datasetIngestor.Datafile, taskId uuid.UUID, folderPath string, ownerUser string, ownerGroup string, contactEmail string, autoArchive bool, transferObjects map[string]interface{}) error {
 	transferMethod := w.GetTransferMethod()
 	t := task.CreateTransferTask(
 		datasetId,
@@ -47,9 +47,11 @@ func (w *TaskQueue) AddTransferTask(datasetId string, fileList []datasetIngestor
 			Id:         taskId,
 			FolderPath: folderPath,
 		},
+		ownerUser,
 		ownerGroup,
-		transferMethod,
+		contactEmail,
 		autoArchive,
+		transferMethod,
 		transferObjects,
 		nil,
 	)

--- a/internal/s3upload/openapi.yaml
+++ b/internal/s3upload/openapi.yaml
@@ -65,7 +65,7 @@ paths:
           description: Internal Server Error
       summary: Get Presigned Urls
       tags:
-        - presignedUrls
+        - s3upload
   /s3/completeUpload:
     post:
       operationId: complete_upload
@@ -96,7 +96,7 @@ paths:
           description: Internal Server Error
       summary: Complete Upload
       tags:
-        - presignedUrls
+        - s3upload
   /s3/abortMultipartUpload:
     post:
       operationId: abort_multipart_upload
@@ -127,7 +127,38 @@ paths:
           description: Internal Server Error
       summary: Abort Multipart Upload
       tags:
-        - presignedUrls
+        - s3upload
+  /s3/finalizeDatasetUpload:
+    post:
+      operationId: FinalizeDatasetUpload
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FinalizeDatasetUploadBody"
+        required: true
+      responses:
+        "201":
+          description: Finalize dataset upload requested
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FinalizeDatasetUploadResp"
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPValidationError"
+          description: Validation Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalError"
+          description: Internal Server Error
+      summary: Finalize Dataset Upload
+      tags:
+        - s3upload
 components:
   securitySchemes:
     BearerAuth: # arbitrary name for the security scheme
@@ -274,6 +305,52 @@ components:
         - Location
         - Key
       title: CompleteUploadResp
+    FinalizeDatasetUploadBody:
+      example:
+        DatasetPID: c2c6bc13-2c14-43d7-91a9-46cd556b258d
+        CreateArchivingJob: true
+        OwnerGroup: Group
+        OwnerUser: User
+        ContactEmail: user@mail.com
+      properties:
+        DatasetPID:
+          title: DatasetPID
+          type: string
+        CreateArchivingJob:
+          title: CreateArchivingJob
+          type: boolean
+        OwnerGroup:
+          title: OwnerGroup
+          type: string
+        OwnerUser:
+          title: OwnerUser
+          type: string
+        ContactEmail:
+          title: ContactEmail
+          type: string
+          format: email
+      required:
+        - DatasetPID
+        - CreateArchivingJob
+        - OwnerGroup
+        - OwnerUser
+        - ContactEmail
+      title: FinalizeDatasetUploadBody
+    FinalizeDatasetUploadResp:
+      example:
+        DatasetID: DatasetID
+        Message: "Upload finalized"
+      properties:
+        DatasetID:
+          title: DatasetID
+          type: string
+        Message:
+          title: Message
+          type: string
+      required:
+        - DatasetID
+        - Message
+      title: FinalizeDatasetUploadResp
     HTTPValidationError:
       example:
         detail:

--- a/internal/s3upload/s3client.go
+++ b/internal/s3upload/s3client.go
@@ -2,4 +2,4 @@
 
 package s3upload
 
-//go:generate go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen -include-tags presignedUrls,service_token --config=cfg.yaml  openapi.yaml
+//go:generate go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen -include-tags s3upload,service_token --config=cfg.yaml  openapi.yaml


### PR DESCRIPTION
**Problems**
1. When using the S3 upload at ETHZ, we cannot deploy a service user as it runs on a user-accessible desktop machine. Therefore, the requests to Scicat are done in the Archiver backend and the ingestor needs to interact with the Archiver backend only.
2. When creating an archiving job, the user's email and user name should be used and not the service user's one.

**Solution**
1. Add a `finalizeUpload` method for S3 upload
2. Pass an `ArchivalJobInfo` object with the necessary information to the finalize methods

**Note**: This is based on https://github.com/SwissOpenEM/Ingestor/pull/131 so there are additional changes in this diff