### PR TITLE
fix (built-in) Globus transfer path to properly use collection locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,13 @@ A recommendation is to have the name of the collection's root folder to be the s
 ## [PR #127] (2025-05-05)
 ### Added
  - (CONFIG) Transfer.StorageLocation sets an ID string in the dataset lifecycle that specifies to which facility we're transmitting the dataset's data
+
+## [PR #135] (2025-05-14)
+### Changed
+ - (Config) Transfer.Globus.SourcePrefixPath was changed to Transfer.Globus.CollectionRootPath due to the change regarding multiple collection locations. 
+
+This changed value **does not** function in the same way: instead of adding a prefix path to the path given as SourceFolder of the dataset, it is now applied after the collection location resolution, making the absolute path relative to the root of the Globus collection. 
+
+Basically, if `location1` is a collection location that points to `/datasets/locations/location1`, and the user gives "/location1/dataset1" as a dataset `SourceFolder`, then the ingestor will first transform it to `/datasets/locations/location1/dataset1`. 
+
+Then, if the `CollectionRootPath` is set to `/datasets/locations`, then that means the Globus collection's root path is mounted there in the filesystem, and the Ingestor will transform the path in a way that removes the upper levels of the path, resulting in `/location1/dataset1` as the source path when requesting a transfer from Globus.

--- a/configs/openem-ingestor-config.yaml
+++ b/configs/openem-ingestor-config.yaml
@@ -5,7 +5,7 @@ Transfer:
     ClientId: "clientid_registered_with_globus"
     RedirectUrl: "https://auth.globus.org/v2/web/auth-code"
     SourceCollectionID: "collectionid1"
-    SourcePrefixPath: "/some/optional/path"
+    CollectionRootPath: "/some/optional/path"
     DestinationCollectionID: "collectionid2"
     DestinationTemplate: "/{{ .Username }}/{{ replace .Pid \".\" \"_\" }}/{{ .DatasetFolder }}"
     Scopes:

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -39,7 +39,7 @@ func createExpectedValidConfigGlobus() transfertask.TransferConfig {
 			RedirectURL:             "https://auth.globus.org/v2/web/auth-code",
 			Scopes:                  []string{"urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/[collection_id1]/data_access]"},
 			SourceCollectionID:      "collectionid1",
-			SourcePrefixPath:        "/some/optional/path",
+			CollectionRootPath:      "/some/optional/path",
 			DestinationCollectionID: "collectionid2",
 			DestinationTemplate:     "/{{ .Username }}/{{ replace .Pid \".\" \"_\" }}/{{ .DatasetFolder }}",
 		},

--- a/internal/core/ingestdataset.go
+++ b/internal/core/ingestdataset.go
@@ -224,11 +224,6 @@ func TransferDataset(
 		if !ok {
 			return fmt.Errorf("username was not set for globus transfer")
 		}
-		// globus doesn't work with absolute folders, this library uses sourcePrefix to adapt the path to the globus' own path from a relative path
-		//_, _, relativeDatasetFolder, err := collections.GetPathDetails(config.WebServer.CollectionLocations, filepath.Clean(datasetFolder))
-		//if err != nil {
-		//	return err
-		//}
 
 		files := make([]globustransfer.File, len(fileList))
 		bytesTotal := int64(0)

--- a/internal/core/ingestdataset.go
+++ b/internal/core/ingestdataset.go
@@ -15,7 +15,6 @@ import (
 	"github.com/SwissOpenEM/Ingestor/internal/globustransfer"
 	"github.com/SwissOpenEM/Ingestor/internal/s3upload"
 	"github.com/SwissOpenEM/Ingestor/internal/transfertask"
-	"github.com/SwissOpenEM/Ingestor/internal/webserver/collections"
 	"github.com/SwissOpenEM/globus"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetUtils"
@@ -226,10 +225,10 @@ func TransferDataset(
 			return fmt.Errorf("username was not set for globus transfer")
 		}
 		// globus doesn't work with absolute folders, this library uses sourcePrefix to adapt the path to the globus' own path from a relative path
-		_, _, relativeDatasetFolder, err := collections.GetPathDetails(config.WebServer.CollectionLocations, filepath.Clean(datasetFolder))
-		if err != nil {
-			return err
-		}
+		//_, _, relativeDatasetFolder, err := collections.GetPathDetails(config.WebServer.CollectionLocations, filepath.Clean(datasetFolder))
+		//if err != nil {
+		//	return err
+		//}
 
 		files := make([]globustransfer.File, len(fileList))
 		bytesTotal := int64(0)
@@ -245,13 +244,13 @@ func TransferDataset(
 		err = globustransfer.TransferFiles(
 			client,
 			config.Transfer.Globus.SourceCollectionID,
-			config.Transfer.Globus.SourcePrefixPath,
+			config.Transfer.Globus.CollectionRootPath,
 			config.Transfer.Globus.DestinationCollectionID,
 			config.Transfer.Globus.DestinationTemplate,
 			transferTask.GetDatasetId(),
 			username,
 			task_context,
-			relativeDatasetFolder,
+			datasetFolder,
 			files,
 			&transferNotifier,
 		)

--- a/internal/globustransfer/transfer.go
+++ b/internal/globustransfer/transfer.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/SwissOpenEM/Ingestor/internal/transfertask"
@@ -48,7 +49,7 @@ func checkTransfer(client *globus.GlobusClient, globusTaskId string) (bytesTrans
 func TransferFiles(
 	client *globus.GlobusClient,
 	SourceCollectionID string,
-	SourcePrefixPath string,
+	CollectionRootPath string,
 	DestinationCollectionID string,
 	DestinationPathTemplate string,
 	datasetId string,
@@ -84,7 +85,7 @@ func TransferFiles(
 
 	result, err := client.TransferFileList(
 		SourceCollectionID,
-		path.Join(SourcePrefixPath, datasetPath),
+		strings.TrimPrefix(datasetPath, CollectionRootPath),
 		DestinationCollectionID,
 		finalDestinationPath,
 		filePathList,

--- a/internal/transfertask/config.go
+++ b/internal/transfertask/config.go
@@ -15,7 +15,7 @@ type GlobusTransferConfig struct {
 	RedirectURL             string   `yaml:"redirectUrl"`
 	Scopes                  []string `yaml:"scopes,omitempty"`
 	SourceCollectionID      string   `yaml:"sourceCollection"`
-	SourcePrefixPath        string   `yaml:"sourcePrefixPath,omitempty"`
+	CollectionRootPath      string   `yaml:"collectionRootPath,omitempty"`
 	DestinationCollectionID string   `yaml:"destinationCollection"`
 	DestinationTemplate     string   `yaml:"destinationTemplate"`
 }

--- a/test/testdata/valid_config_globus.yaml
+++ b/test/testdata/valid_config_globus.yaml
@@ -9,7 +9,7 @@ Transfer:
     ClientId: "clientid_registered_with_globus"
     RedirectUrl: "https://auth.globus.org/v2/web/auth-code"
     SourceCollectionID: "collectionid1"
-    SourcePrefixPath: "/some/optional/path"
+    CollectionRootPath: "/some/optional/path"
     DestinationCollectionID: "collectionid2"
     DestinationTemplate: "/{{ .Username }}/{{ replace .Pid \".\" \"_\" }}/{{ .DatasetFolder }}"
     Scopes:


### PR DESCRIPTION
This fixes a bug that came from the introduction of multiple collection locations in the (built-in) Globus transfer method. Now the paths are properly translated, but this also needed a change in the configuration.