### PR TITLE
Feature/data access control

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -65,6 +65,18 @@ paths:
               text/plain:
                 schema:
                   type: string
+          "401":
+            description: "Unauthorized access:  the path is not allowed for the user, or the user is not logged in"
+            content:
+              text/plain:
+                schema:
+                  type: string
+          "500":
+            description: Internal server error
+            content:
+              text/plain:
+                schema:
+                  type: string
 
   /dataset:
     post:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -107,6 +107,18 @@ paths:
             text/plain:
               schema:
                 type: string
+        "401":
+          description: Unauthorized access - you don't have access to the dataset or path indicated in the request
+          content:
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Internal Server Error
+          content:
+            text/plain:
+              schema:
+                type: string
 
   /transfer:
     get:

--- a/internal/core/ingestdataset.go
+++ b/internal/core/ingestdataset.go
@@ -104,18 +104,6 @@ func createLocalFilenameFilterCallback(illegalFileNamesCounter *uint) func(filep
 	}
 }
 
-func CheckIfFolderExists(path string) error {
-	// check if the folder exists
-	fileInfo, err := os.Stat(path)
-	if err != nil {
-		return err
-	}
-	if !fileInfo.IsDir() {
-		return errors.New("'sourceFolder' is not a directory")
-	}
-	return nil
-}
-
 func AddDatasetToScicat(
 	metaDataMap map[string]interface{},
 	datasetFolder string,

--- a/internal/datasetaccess/accessfile.go
+++ b/internal/datasetaccess/accessfile.go
@@ -1,0 +1,6 @@
+package datasetaccess
+
+type accessFile struct {
+	Path         string   `yaml:"Path"`
+	AccessGroups []string `yaml:"AccessGroups"`
+}

--- a/internal/datasetaccess/accessfile.go
+++ b/internal/datasetaccess/accessfile.go
@@ -1,7 +1,8 @@
 package datasetaccess
 
 type accessFile struct {
-	Path          string   `yaml:"Path"`
-	AllowedGroups []string `yaml:"AllowedGroups"`
-	BlockedGroups []string `yaml:"BlockedGroups"`
+	Path              string   `yaml:"Path"`
+	HasDatasetFolders bool     `yaml:"HasDatasetFolders"`
+	AllowedGroups     []string `yaml:"AllowedGroups"`
+	BlockedGroups     []string `yaml:"BlockedGroups"`
 }

--- a/internal/datasetaccess/accessfile.go
+++ b/internal/datasetaccess/accessfile.go
@@ -1,6 +1,7 @@
 package datasetaccess
 
 type accessFile struct {
-	Path         string   `yaml:"Path"`
-	AccessGroups []string `yaml:"AccessGroups"`
+	Path          string   `yaml:"Path"`
+	AllowedGroups []string `yaml:"AllowedGroups"`
+	BlockedGroups []string `yaml:"BlockedGroups"`
 }

--- a/internal/datasetaccess/checkaccess.go
+++ b/internal/datasetaccess/checkaccess.go
@@ -28,13 +28,16 @@ func parseAccessFile(path string) (accessFile, error) {
 
 func CheckAccessIntegrity(path string) error {
 	splitPath := strings.Split(filepath.Clean(path), string(filepath.Separator))
-	allFoundGroups := map[string]bool{}
+	allFoundAllowedGroups := map[string]bool{}
 
 	// check if the access hierarchy follows the rules by traversing parent directories
 	prevPath := ""
 	for i := len(splitPath); i > 0; i-- {
 		/// read and parse file
 		currPath := filepath.Join(append(splitPath[0:i], accessControlFilename)...)
+		if splitPath[0] == "" {
+			currPath = string(filepath.Separator) + currPath // UNIX fix
+		}
 
 		if _, err := os.Stat(currPath); errors.Is(err, os.ErrNotExist) {
 			continue // skip the path if it doesn't contain any access restrictions
@@ -56,7 +59,7 @@ func CheckAccessIntegrity(path string) error {
 		}
 
 		invalidGroups := []string{}
-		for group := range allFoundGroups {
+		for group := range allFoundAllowedGroups {
 			if _, ok := parsedGroups[group]; !ok {
 				invalidGroups = append(invalidGroups, group)
 			}
@@ -67,7 +70,7 @@ func CheckAccessIntegrity(path string) error {
 
 		// update map of all encountered groups
 		for group := range parsedGroups {
-			allFoundGroups[group] = true
+			allFoundAllowedGroups[group] = true
 		}
 		prevPath = currPath
 	}

--- a/internal/datasetaccess/checkaccess.go
+++ b/internal/datasetaccess/checkaccess.go
@@ -1,0 +1,59 @@
+package datasetaccess
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+const accessControlFilename = "openem-access.yaml"
+
+func CheckAccess(path string, hasGroups []string) error {
+	splitPath := strings.Split(filepath.Clean(path), string(filepath.Separator))
+
+	allowedGroups := map[string]bool{}
+	hasGroupsMap := map[string]bool{}
+	for _, group := range hasGroups {
+		hasGroupsMap[group] = true
+	}
+
+	firstFile := true
+	for i := len(splitPath) - 1; i >= 0; i-- {
+		path := filepath.Join(append(splitPath[0:i], accessControlFilename)...)
+		rawAccessFile, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		var parsedAccessFile accessFile
+		yaml.Unmarshal(rawAccessFile, &parsedAccessFile)
+		if firstFile {
+			firstFile = false
+			for _, group := range parsedAccessFile.AccessGroups {
+				allowedGroups[group] = true
+			}
+		} else {
+			invalidGroups := []string{}
+			for _, group := range parsedAccessFile.AccessGroups {
+				if _, ok := allowedGroups[group]; !ok {
+					invalidGroups = append(invalidGroups, group)
+				}
+			}
+			if len(invalidGroups) > 0 {
+				return NewInvalidGroupsError(path, invalidGroups)
+			}
+		}
+	}
+
+	allowedGroupsSlice := make([]string, 0, len(allowedGroups))
+	for group := range allowedGroups {
+		if _, ok := hasGroupsMap[group]; ok {
+			return nil
+		}
+		allowedGroupsSlice = append(allowedGroupsSlice, group)
+	}
+
+	return NewAccessError(allowedGroupsSlice)
+}

--- a/internal/datasetaccess/checkaccess.go
+++ b/internal/datasetaccess/checkaccess.go
@@ -1,11 +1,15 @@
 package datasetaccess
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
 	"gopkg.in/yaml.v2"
 )
 
@@ -70,7 +74,18 @@ func CheckAccessIntegrity(path string) error {
 	return nil
 }
 
-func CheckUserAccess(path string, hasGroups []string) error {
+func CheckUserAccess(ctx context.Context, path string) error {
+	ginCtx, ok := ctx.(*gin.Context)
+	if !ok {
+		return fmt.Errorf("internal context error")
+	}
+
+	userSession := sessions.DefaultMany(ginCtx, "user")
+	hasGroups, ok := userSession.Get("access_groups").([]string)
+	if !ok {
+		return fmt.Errorf("internal user session error: can't get access groups of user")
+	}
+
 	splitPath := strings.Split(filepath.Clean(path), string(filepath.Separator))
 
 	allowedGroups := map[string]bool{}

--- a/internal/datasetaccess/checkaccess.go
+++ b/internal/datasetaccess/checkaccess.go
@@ -1,6 +1,7 @@
 package datasetaccess
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,7 +11,64 @@ import (
 
 const accessControlFilename = "openem-access.yaml"
 
-func CheckAccess(path string, hasGroups []string) error {
+func parseAccessFile(path string) (accessFile, error) {
+	rawAccessFile, err := os.ReadFile(path)
+	if err != nil {
+		return accessFile{}, err
+	}
+
+	var parsedAccessFile accessFile
+	err = yaml.Unmarshal(rawAccessFile, &parsedAccessFile)
+	return parsedAccessFile, err
+}
+
+func CheckAccessIntegrity(path string) error {
+	splitPath := strings.Split(filepath.Clean(path), string(filepath.Separator))
+	allFoundGroups := map[string]bool{}
+
+	// check if the access hierarchy follows the rules by traversing parent directories
+	for i := len(splitPath); i > 0; i-- {
+		/// read and parse file
+		path := filepath.Join(append(splitPath[0:i], accessControlFilename)...)
+
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			continue // skip the path if it doesn't contain any access restrictions
+		}
+
+		parsedAccessFile, err := parseAccessFile(path)
+		if err != nil {
+			return err
+		}
+
+		// path rule check
+		if parsedAccessFile.Path != path {
+			return newPathError(parsedAccessFile.Path, path)
+		}
+
+		parsedGroups := map[string]bool{}
+		for _, group := range parsedAccessFile.AccessGroups {
+			parsedGroups[group] = true
+		}
+
+		invalidGroups := []string{}
+		for group := range allFoundGroups {
+			if _, ok := parsedGroups[group]; !ok {
+				invalidGroups = append(invalidGroups, group)
+			}
+		}
+		if len(invalidGroups) > 0 { // return an error in case of any mismatched groups
+			return newInvalidGroupsError(path, invalidGroups)
+		}
+
+		// update map of all encountered groups
+		for group := range parsedGroups {
+			allFoundGroups[group] = true
+		}
+	}
+	return nil
+}
+
+func CheckUserAccess(path string, hasGroups []string) error {
 	splitPath := strings.Split(filepath.Clean(path), string(filepath.Separator))
 
 	allowedGroups := map[string]bool{}
@@ -19,34 +77,27 @@ func CheckAccess(path string, hasGroups []string) error {
 		hasGroupsMap[group] = true
 	}
 
-	firstFile := true
-	for i := len(splitPath) - 1; i >= 0; i-- {
+	for i := len(splitPath); i > 0; i-- {
+		/// read and parse file
 		path := filepath.Join(append(splitPath[0:i], accessControlFilename)...)
-		rawAccessFile, err := os.ReadFile(path)
+
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			continue // skip the path if it doesn't contain any access restrictions
+		}
+
+		parsedAccessFile, err := parseAccessFile(path)
 		if err != nil {
 			return err
 		}
 
-		var parsedAccessFile accessFile
-		yaml.Unmarshal(rawAccessFile, &parsedAccessFile)
-		if firstFile {
-			firstFile = false
-			for _, group := range parsedAccessFile.AccessGroups {
-				allowedGroups[group] = true
-			}
-		} else {
-			invalidGroups := []string{}
-			for _, group := range parsedAccessFile.AccessGroups {
-				if _, ok := allowedGroups[group]; !ok {
-					invalidGroups = append(invalidGroups, group)
-				}
-			}
-			if len(invalidGroups) > 0 {
-				return NewInvalidGroupsError(path, invalidGroups)
-			}
+		// the first file closest to the final path determines the strictest level of required groups
+		for _, group := range parsedAccessFile.AccessGroups {
+			allowedGroups[group] = true
 		}
+		break // no need to continue iterate further, we got the (theoretical) strictest set of groups
 	}
 
+	// check if user has required groups
 	allowedGroupsSlice := make([]string, 0, len(allowedGroups))
 	for group := range allowedGroups {
 		if _, ok := hasGroupsMap[group]; ok {
@@ -55,5 +106,5 @@ func CheckAccess(path string, hasGroups []string) error {
 		allowedGroupsSlice = append(allowedGroupsSlice, group)
 	}
 
-	return NewAccessError(allowedGroupsSlice)
+	return newAccessError(allowedGroupsSlice)
 }

--- a/internal/datasetaccess/checkaccess.go
+++ b/internal/datasetaccess/checkaccess.go
@@ -97,6 +97,9 @@ func CheckUserAccess(ctx context.Context, path string) error {
 	for i := len(splitPath); i > 0; i-- {
 		/// read and parse file
 		path := filepath.Join(append(splitPath[0:i], accessControlFilename)...)
+		if splitPath[0] == "" {
+			path = string(filepath.Separator) + path // UNIX fix
+		}
 
 		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 			continue // skip the path if it doesn't contain any access restrictions
@@ -112,6 +115,11 @@ func CheckUserAccess(ctx context.Context, path string) error {
 			allowedGroups[group] = true
 		}
 		break // no need to continue iterate further, we got the (theoretical) strictest set of groups
+	}
+
+	// if there's no allowed group found, allow all
+	if len(allowedGroups) == 0 {
+		return nil
 	}
 
 	// check if user has required groups

--- a/internal/datasetaccess/checks.go
+++ b/internal/datasetaccess/checks.go
@@ -26,14 +26,25 @@ func parseAccessFile(path string) (accessFile, error) {
 	return parsedAccessFile, err
 }
 
-func CheckAccessIntegrity(path string) error {
-	splitPath := strings.Split(filepath.Clean(path), string(filepath.Separator))
-	allFoundAllowedGroups := map[string]bool{}
-	lowestLevelBlockedGroups := map[string]bool{}
+func CheckUserAccess(ctx context.Context, path string) error {
+	ginCtx, ok := ctx.(*gin.Context)
+	if !ok {
+		return fmt.Errorf("internal context error")
+	}
 
-	// check if the access hierarchy follows the rules by traversing parent directories
-	prevPath := ""
-	encounteredAccessFile := false
+	userSession := sessions.DefaultMany(ginCtx, "user")
+	userGroups, ok := userSession.Get("access_groups").([]string)
+	if !ok {
+		return fmt.Errorf("internal user session error: can't get access groups of user")
+	}
+
+	splitPath := strings.Split(filepath.Clean(path), string(filepath.Separator))
+	allowedGroups := map[string]bool{}
+	blockedGroups := map[string]bool{}
+	conflictedGroups := []string{}
+	invalidAllowGroups := []string{}
+
+	// assemble allowed and blocked group sets
 	for i := len(splitPath); i > 0; i-- {
 		/// read and parse file
 		currPath := filepath.Join(append(splitPath[0:i], accessControlFilename)...)
@@ -55,135 +66,67 @@ func CheckAccessIntegrity(path string) error {
 			return newPathError(parsedAccessFile.Path, currPath)
 		}
 
-		// find invalid allowed groups
-		parsedAllowedGroups := map[string]bool{}
-		for _, group := range parsedAccessFile.AllowedGroups {
-			parsedAllowedGroups[group] = true
-		}
-
-		// check if the upper levels define an allowed groups list while the lower levels don't
-		invalidAllowedGroups := []string{}
-		if len(allFoundAllowedGroups) == 0 && len(parsedAllowedGroups) > 0 && encounteredAccessFile {
-			// if yes, add all discovered groups to the invalid list
-			for group := range parsedAllowedGroups {
-				invalidAllowedGroups = append(invalidAllowedGroups, group)
+		// find groups
+		if len(allowedGroups) > 0 {
+			// check if lowest level allowed groups list align with upper levels (same or stricter set of groups)
+			currAllowedGroups := map[string]bool{}
+			for _, group := range parsedAccessFile.AllowedGroups {
+				currAllowedGroups[group] = true
 			}
-		} else { // otherwise find groups that only appeared on the lower levels
-			for group := range allFoundAllowedGroups {
-				if _, ok := parsedAllowedGroups[group]; !ok {
-					invalidAllowedGroups = append(invalidAllowedGroups, group)
+			for group := range allowedGroups {
+				if _, ok := currAllowedGroups[group]; !ok {
+					invalidAllowGroups = append(invalidAllowGroups, group)
 				}
-			}
-		}
-
-		// find invalid blocked groups (ones that only appeared on the upper levels of the path)
-		invalidBlockedGroups := []string{}
-		if len(lowestLevelBlockedGroups) == 0 {
-			for _, group := range parsedAccessFile.BlockedGroups {
-				lowestLevelBlockedGroups[group] = true
 			}
 		} else {
-			for _, group := range parsedAccessFile.BlockedGroups {
-				if _, ok := lowestLevelBlockedGroups[group]; !ok {
-					invalidBlockedGroups = append(invalidBlockedGroups, group)
-				}
+			// set final list of allow groups (lowest level where it's defined)
+			for _, group := range parsedAccessFile.AllowedGroups {
+				allowedGroups[group] = true
 			}
-		}
-
-		// return an error in case of any mismatched groups
-		if len(invalidAllowedGroups) > 0 || len(invalidBlockedGroups) > 0 {
-			return newInvalidGroupsError(prevPath, currPath, invalidAllowedGroups, invalidBlockedGroups)
-		}
-
-		// update map of all encountered allowed groups
-		for group := range parsedAllowedGroups {
-			allFoundAllowedGroups[group] = true
-		}
-		prevPath = currPath
-		encounteredAccessFile = true
-	}
-	return nil
-}
-
-func CheckUserAccess(ctx context.Context, path string) error {
-	ginCtx, ok := ctx.(*gin.Context)
-	if !ok {
-		return fmt.Errorf("internal context error")
-	}
-
-	userSession := sessions.DefaultMany(ginCtx, "user")
-	hasGroups, ok := userSession.Get("access_groups").([]string)
-	if !ok {
-		return fmt.Errorf("internal user session error: can't get access groups of user")
-	}
-
-	splitPath := strings.Split(filepath.Clean(path), string(filepath.Separator))
-
-	allowedGroups := map[string]bool{}
-	blockedGroups := map[string]bool{}
-	userGroupsMap := map[string]bool{}
-	for _, group := range hasGroups {
-		userGroupsMap[group] = true
-	}
-
-	for i := len(splitPath); i > 0; i-- {
-		/// read and parse file
-		path := filepath.Join(append(splitPath[0:i], accessControlFilename)...)
-		if splitPath[0] == "" {
-			path = string(filepath.Separator) + path // UNIX fix
-		}
-
-		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-			continue // skip the path if it doesn't contain any access restrictions
-		}
-
-		parsedAccessFile, err := parseAccessFile(path)
-		if err != nil {
-			return err
-		}
-
-		// the first file closest to the final path determines the strictest level of allowed and blocked groups
-		for _, group := range parsedAccessFile.AllowedGroups {
-			allowedGroups[group] = true
 		}
 		for _, group := range parsedAccessFile.BlockedGroups {
 			blockedGroups[group] = true
 		}
-		break // no need to continue iterate further, we got the (theoretical) strictest set of groups
 	}
 
-	// if there's no allowed group found, allow all
-	if len(allowedGroups) == 0 {
-		return nil
-	}
-
-	// check if user has required groups
-	failedWhitelist := true
-	for group := range allowedGroups {
-		if _, ok := userGroupsMap[group]; ok {
-			failedWhitelist = false
-			break // if the user has at least one group from the list, continue
-		}
-	}
-
-	// check if user should be blocked based on group membership
-	userBlockedGroupsSlice := []string{}
+	// check for conflicted groups
 	for group := range blockedGroups {
-		if _, ok := userGroupsMap[group]; ok {
-			userBlockedGroupsSlice = append(userBlockedGroupsSlice, group)
+		if _, ok := allowedGroups[group]; ok {
+			conflictedGroups = append(conflictedGroups, group)
 		}
 	}
 
-	// return error if found, otherwise return nil
-	if failedWhitelist || len(userBlockedGroupsSlice) > 0 {
-		allowedGroupsSlice := make([]string, 0, len(allowedGroups))
-		if failedWhitelist {
-			for k := range allowedGroups {
-				allowedGroupsSlice = append(allowedGroupsSlice, k)
-			}
-		}
-		return newAccessError(allowedGroupsSlice, userBlockedGroupsSlice)
+	if len(conflictedGroups) > 0 || len(invalidAllowGroups) > 0 {
+		return newGroupError(path, invalidAllowGroups, conflictedGroups)
 	}
+
+	// check user permissions based on groups
+	failedWhitelist := false
+	userBlockedGroups := []string{}
+	if len(allowedGroups) > 0 {
+		failedWhitelist = true
+	}
+	for _, group := range userGroups {
+		if _, ok := allowedGroups[group]; ok {
+			failedWhitelist = false
+			break
+		}
+		if _, ok := blockedGroups[group]; ok {
+			userBlockedGroups = append(userBlockedGroups, group)
+		}
+	}
+
+	// return error if user doesn't have the access rights
+	if failedWhitelist {
+		allowedGroupsList := make([]string, 0, len(allowedGroups))
+		for k := range allowedGroups {
+			allowedGroupsList = append(allowedGroupsList, k)
+		}
+		return newAccessError(allowedGroupsList, userBlockedGroups)
+	} else if len(userBlockedGroups) > 0 {
+		return newAccessError([]string{}, userBlockedGroups)
+	}
+
 	return nil
 }
 

--- a/internal/datasetaccess/checks.go
+++ b/internal/datasetaccess/checks.go
@@ -189,7 +189,7 @@ func IsFolderCheck(path string) error {
 }
 
 func IsDatasetFolder(path string) bool {
-	accessFile, err := parseAccessFile(filepath.Dir(path))
+	accessFile, err := parseAccessFile(filepath.Join(filepath.Dir(path), accessControlFilename))
 	if err == nil {
 		return accessFile.HasDatasetFolders
 	}

--- a/internal/datasetaccess/checks.go
+++ b/internal/datasetaccess/checks.go
@@ -187,3 +187,11 @@ func IsFolderCheck(path string) error {
 	}
 	return nil
 }
+
+func IsDatasetFolder(path string) bool {
+	accessFile, err := parseAccessFile(filepath.Dir(path))
+	if err == nil {
+		return accessFile.HasDatasetFolders
+	}
+	return false
+}

--- a/internal/datasetaccess/errors.go
+++ b/internal/datasetaccess/errors.go
@@ -38,7 +38,7 @@ type InvalidGroupsError struct {
 func (e *InvalidGroupsError) Error() string {
 	listErrs := []string{}
 	if len(e.invalidAllowedGroups) > 0 {
-		listErrs = append(listErrs, fmt.Sprintf("the following allowed blocks at %s are invalid: %v", e.allowPath, e.invalidAllowedGroups))
+		listErrs = append(listErrs, fmt.Sprintf("the following allowed groups at %s are invalid: %v", e.allowPath, e.invalidAllowedGroups))
 	}
 	if len(e.invalidBlockedGroups) > 0 {
 		listErrs = append(listErrs, fmt.Sprintf("the following blocked groups at %s are invalid: '%v'", e.blockPath, e.invalidBlockedGroups))

--- a/internal/datasetaccess/errors.go
+++ b/internal/datasetaccess/errors.go
@@ -1,0 +1,33 @@
+package datasetaccess
+
+import "fmt"
+
+type AccessError struct {
+	groupsWithAccess []string
+}
+
+func (e *AccessError) Error() string {
+	return fmt.Sprintf("the user does not have access to the datasets, one of the following groups is needed: %v", e.groupsWithAccess)
+}
+
+func NewAccessError(groupsWithAccess []string) *AccessError {
+	return &AccessError{
+		groupsWithAccess: groupsWithAccess,
+	}
+}
+
+type InvalidGroupsError struct {
+	currentPath   string
+	invalidGroups []string
+}
+
+func (e *InvalidGroupsError) Error() string {
+	return fmt.Sprintf("the following invalid groups were found when checking the path '%s': '%v'", e.currentPath, e.invalidGroups)
+}
+
+func NewInvalidGroupsError(path string, groups []string) *InvalidGroupsError {
+	return &InvalidGroupsError{
+		currentPath:   path,
+		invalidGroups: groups,
+	}
+}

--- a/internal/datasetaccess/errors.go
+++ b/internal/datasetaccess/errors.go
@@ -28,31 +28,28 @@ func newAccessError(groupsWithAccess []string, blockedGroups []string) *AccessEr
 	}
 }
 
-type InvalidGroupsError struct {
-	allowPath            string
-	blockPath            string
-	invalidAllowedGroups []string
-	invalidBlockedGroups []string
+type GroupError struct {
+	path               string
+	invalidAllowGroups []string
+	conflictedGroups   []string
 }
 
-func (e *InvalidGroupsError) Error() string {
-	listErrs := []string{}
-	if len(e.invalidAllowedGroups) > 0 {
-		listErrs = append(listErrs, fmt.Sprintf("the following allowed groups at %s are invalid: %v", e.allowPath, e.invalidAllowedGroups))
+func (e *GroupError) Error() string {
+	errList := []string{}
+	if len(e.invalidAllowGroups) > 0 {
+		errList = append(errList, fmt.Sprintf("invalid allow groups found on a lower level: %v", e.invalidAllowGroups))
 	}
-	if len(e.invalidBlockedGroups) > 0 {
-		listErrs = append(listErrs, fmt.Sprintf("the following blocked groups at %s are invalid: '%v'", e.blockPath, e.invalidBlockedGroups))
-
+	if len(e.conflictedGroups) > 0 {
+		errList = append(errList, fmt.Sprintf("the following groups are in conflict: %v", e.conflictedGroups))
 	}
-	return fmt.Sprintf("invalid groups error - %s", strings.Join(listErrs, ", "))
+	return "the following group errors occured at '" + e.path + "': " + strings.Join(errList, ", ")
 }
 
-func newInvalidGroupsError(allowPath string, blockPath string, allowedGroups []string, blockedGroups []string) *InvalidGroupsError {
-	return &InvalidGroupsError{
-		allowPath:            allowPath,
-		blockPath:            blockPath,
-		invalidAllowedGroups: allowedGroups,
-		invalidBlockedGroups: blockedGroups,
+func newGroupError(path string, invalidAllowGroups []string, conflictedGroups []string) *GroupError {
+	return &GroupError{
+		path:               path,
+		invalidAllowGroups: invalidAllowGroups,
+		conflictedGroups:   conflictedGroups,
 	}
 }
 

--- a/internal/datasetaccess/errors.go
+++ b/internal/datasetaccess/errors.go
@@ -29,18 +29,30 @@ func newAccessError(groupsWithAccess []string, blockedGroups []string) *AccessEr
 }
 
 type InvalidGroupsError struct {
-	currentPath   string
-	invalidGroups []string
+	allowPath            string
+	blockPath            string
+	invalidAllowedGroups []string
+	invalidBlockedGroups []string
 }
 
 func (e *InvalidGroupsError) Error() string {
-	return fmt.Sprintf("the following invalid groups were found when checking the path '%s': '%v'", e.currentPath, e.invalidGroups)
+	listErrs := []string{}
+	if len(e.invalidAllowedGroups) > 0 {
+		listErrs = append(listErrs, fmt.Sprintf("the following allowed blocks at %s are invalid: %v", e.allowPath, e.invalidAllowedGroups))
+	}
+	if len(e.invalidBlockedGroups) > 0 {
+		listErrs = append(listErrs, fmt.Sprintf("the following blocked groups at %s are invalid: '%v'", e.blockPath, e.invalidBlockedGroups))
+
+	}
+	return fmt.Sprintf("invalid groups error - %s", strings.Join(listErrs, ", "))
 }
 
-func newInvalidGroupsError(path string, groups []string) *InvalidGroupsError {
+func newInvalidGroupsError(allowPath string, blockPath string, allowedGroups []string, blockedGroups []string) *InvalidGroupsError {
 	return &InvalidGroupsError{
-		currentPath:   path,
-		invalidGroups: groups,
+		allowPath:            allowPath,
+		blockPath:            blockPath,
+		invalidAllowedGroups: allowedGroups,
+		invalidBlockedGroups: blockedGroups,
 	}
 }
 

--- a/internal/datasetaccess/errors.go
+++ b/internal/datasetaccess/errors.go
@@ -1,18 +1,30 @@
 package datasetaccess
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type AccessError struct {
 	groupsWithAccess []string
+	blockedGroups    []string
 }
 
 func (e *AccessError) Error() string {
-	return fmt.Sprintf("the user does not have access to the datasets, one of the following groups is needed: %v", e.groupsWithAccess)
+	listErrs := []string{}
+	if len(e.groupsWithAccess) > 0 {
+		listErrs = append(listErrs, fmt.Sprintf("one of the following groups is needed: %v", e.groupsWithAccess))
+	}
+	if len(e.blockedGroups) > 0 {
+		listErrs = append(listErrs, fmt.Sprintf("the following groups to which the user belongs are blocked from accessing it: %v", e.blockedGroups))
+	}
+	return fmt.Sprintf("the user does not have access to the datasets - %s", strings.Join(listErrs, ", "))
 }
 
-func newAccessError(groupsWithAccess []string) *AccessError {
+func newAccessError(groupsWithAccess []string, blockedGroups []string) *AccessError {
 	return &AccessError{
 		groupsWithAccess: groupsWithAccess,
+		blockedGroups:    blockedGroups,
 	}
 }
 

--- a/internal/datasetaccess/errors.go
+++ b/internal/datasetaccess/errors.go
@@ -10,7 +10,7 @@ func (e *AccessError) Error() string {
 	return fmt.Sprintf("the user does not have access to the datasets, one of the following groups is needed: %v", e.groupsWithAccess)
 }
 
-func NewAccessError(groupsWithAccess []string) *AccessError {
+func newAccessError(groupsWithAccess []string) *AccessError {
 	return &AccessError{
 		groupsWithAccess: groupsWithAccess,
 	}
@@ -25,9 +25,25 @@ func (e *InvalidGroupsError) Error() string {
 	return fmt.Sprintf("the following invalid groups were found when checking the path '%s': '%v'", e.currentPath, e.invalidGroups)
 }
 
-func NewInvalidGroupsError(path string, groups []string) *InvalidGroupsError {
+func newInvalidGroupsError(path string, groups []string) *InvalidGroupsError {
 	return &InvalidGroupsError{
 		currentPath:   path,
 		invalidGroups: groups,
+	}
+}
+
+type PathError struct {
+	yamlPath   string
+	actualPath string
+}
+
+func (e *PathError) Error() string {
+	return fmt.Sprintf("the path indicated in the '%s' access file is different from the actual path - got: '%s', wanted: '%s'", accessControlFilename, e.yamlPath, e.actualPath)
+}
+
+func newPathError(yamlPath string, actualPath string) *PathError {
+	return &PathError{
+		yamlPath:   yamlPath,
+		actualPath: actualPath,
 	}
 }

--- a/internal/datasetaccess/errors.go
+++ b/internal/datasetaccess/errors.go
@@ -47,3 +47,15 @@ func newPathError(yamlPath string, actualPath string) *PathError {
 		actualPath: actualPath,
 	}
 }
+
+type NotFolderError struct {
+	path string
+}
+
+func (e *NotFolderError) Error() string {
+	return "the path at '" + e.path + "' is not a folder"
+}
+
+func newNotFolderError(path string) *NotFolderError {
+	return &NotFolderError{path: path}
+}

--- a/internal/webserver/api.gen.go
+++ b/internal/webserver/api.gen.go
@@ -799,6 +799,26 @@ func (response DatasetControllerBrowseFilesystem400TextResponse) VisitDatasetCon
 	return err
 }
 
+type DatasetControllerBrowseFilesystem401TextResponse string
+
+func (response DatasetControllerBrowseFilesystem401TextResponse) VisitDatasetControllerBrowseFilesystemResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(401)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
+type DatasetControllerBrowseFilesystem500TextResponse string
+
+func (response DatasetControllerBrowseFilesystem500TextResponse) VisitDatasetControllerBrowseFilesystemResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(500)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
 type ExtractorControllerGetExtractorMethodsRequestObject struct {
 	Params ExtractorControllerGetExtractorMethodsParams
 }
@@ -1512,62 +1532,63 @@ func (sh *strictHandler) OtherControllerGetVersion(ctx *gin.Context) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xb628buRH/VwbbAkkAWXYv6X3wN5/j5NTmhTgpUMRGjlqOJF4ockNypegO/t+L4WMf",
-	"2l09mvh6h+s3a5fLGc7jx98M6V+zXC8LrVA5m53/mtl8gUvm/3yKEh2+M0zZGZq3+LlE6+hFYXSBxgn0",
-	"w3gYxuyn8MvmRhROaJWdZ2IGboGAypkNKERuwWmYIoSPOGgDSrsRCAWMc0Gf0YicqRylFGoOwsHD6QY4",
-	"zlgpHcyYtPgoG2VuU2B2nk21lshUdjfKbC5y5t7pT6gGNRFqjtZpA8JCrtVMzEuDnESWFuHqi3su9bS0",
-	"12hWIkeYaQMuGmAEbiEsoOKFFsrF5TC4zsUlc+C83Eov64xQc1IrfT/hPVpx0EGxNArcgjmwC11KToaK",
-	"lkDenfpulBn8XAqDPDv/0JRzW43V058xd6TGtjdtoZXFrjutY660XVVf4RrCu22Vx8euOikBggObzTB3",
-	"X7+8K2O06a4m19yvsaPfEq1l8753W3L9DPX4PtnPtORoXkVR7bUyWKJbaA7C4RLCuylab8Dw5oEFxZYI",
-	"THEI2ZeNtlexEJKbENbduKeve9dYMLfof2H0lE3l5ilzzKLrm3bLCl5GnHFU69Odqs8+z9H9YPTaYhw0",
-	"HHwzb0n/J9nL//FXg7PsPPvLaQ1UpxGlThuWv6sEM2PYxv/Wjsme8KPHoMrlFA3FchRKYTzTZslcdp6V",
-	"Qrk6JIVyOEfTsUpSN4kaWPzVF2dY7vSOrAuh0JN2L4R1KeGW6BhnjgGGCQksY3SRf1qIJlQL77LRYQZ9",
-	"6aebOFx+hUHTYvbarzFwl/32g9aBiiUMseMe3WrMOjz+kmb9BrvrWU7DwPeDFYNoEMfvBbyY6nF4n0te",
-	"uwWaH5FJtxh2CRIg+7/Sxs7km7bTOnvGtqChvei6tQ+lGB/v3UPifIkqXKef87Dph5+DK/4XGiu0Gl7y",
-	"Kgzo6hu/PEzhjvA32roKOQdIGCudvjD5Qqx69qD1Akl/Yjk0joVxXhUe5h3D08ivhIV3b99f9RIswh9S",
-	"pCfRmugUV5mm7mMHpUUzQNTo0+CeQKk8ByOwU3PQCqa4YHKWZNA8e71eqd2Ue7vP0MfyIzLBAD+CS0aK",
-	"k7aealpUHCjZPaWAKcs/0WO/IHE8m6LPlPhcNkhkzSujF+pXP+vp+GvJVgv2OhaabhzadwmRqy1VKPf9",
-	"k17cDR/EOb0GB302E3JAzuPvdnwwLGfgs2Gq2EQoVOWSTLdmgmI1q51mws+ZUMIuPNOdMREYfZPdC7Vi",
-	"UvAYRA27D4XBwS6s1Ozz5XuLZqJmugfBl0zI3lXjl0IYtB+Za5mQM4cnTvjto/PNjC2F3Hwc3J7mYoVq",
-	"+LXU8znyj+JoDmwwOPsj5f6OYZqio/ed0RLblGBo56qIki2Dffd6qV5W1zc0D+alEW5zTZtxqmj0J4EX",
-	"ZaD2ZI/4KEtWyNqoyArxTyQ2ckcxFhzdRpC3aB1cvJl4qM31clkqwl/h4datEQOXnKTa+f3EE5DqNwEY",
-	"QZoNVfMYCJK2HjbmRQtr4RZ+zquXJ7F+rj6+UfQ5qcOk1GvbLo/1zEPayO9kS+ZE3kuLPUEKaJxg9nOJ",
-	"RmCgfsKRr7MoulrIxZtJNqq38exv47PxGflTF6hYIbLz7PH4bPw4VkLeH6c5k5IWSz/moZiiLPL2o0Ql",
-	"BnuZxtCHhi3ReZb5YdsTz7SBBVPcdz5o3ax0C23EL8EbVIuCwRzFCjnMjF76Qa8nTy+hMHoluHe8Dwpa",
-	"7qaOiVjG1rHnTIk7SeG2bpXiPkwur98+I5kOvcEHpJILjhN7S4PD3uvN+/jsu27A+gUnu4Mt8xytnZUy",
-	"G2ULZKmClDoEcfd7g1wYzB28f/si26UN5cyTs7OQd8qhCimNX9xpIVkAox1fj3bqHXYB4LRxa0jw732s",
-	"DQTT3Y2yv387+RPlCAMlXKNZoYHQNGkCTXb+4Zbga7lkZrOtMWUOm1PcEt9coHIRJrJbmuOU1+2EQgeW",
-	"2pZ/aZA5BFaxEpS4ROWoWo256BOXcCORF7JNeEeZ286sSNYutXJGS0kbGWVy6kWEuEPrftB8s2VDVhQy",
-	"an/6s9VbltxV8/XQ8bs2rFOM323F8XcdL34jDSJP7fF2HBLLDcKPRqZ828CexOA1lUFaIdXetT5kqQD6",
-	"uDbCYXZ714q54ERgoHCdIqUReulJK+ZOp77B1MDg7S3OGYGx6AltG7DOlLkrDSau7CkIELIfEGqho/WM",
-	"KOXGEg/uQHsfIMYG2jAettV+w9wiaRe13ugS1kw530j3OvTS+SHxc8x2iZtjapcQyBdsLpS3wWHNsWGh",
-	"1+KXXYJfdVs0UKBXAA8SfXuP6TbYvuxJhNSui53BRsbJDZgYhHz8O0k/g4xvZ99zpNSTW+twGhjYAnMx",
-	"E3mVIv0piandeVg2shUTkk0ldtuauzqa3RSt2qx1kjabry+rZuNBefr/RPlvEqXb6u4J14ttj2tj6+Sg",
-	"nEkp8/WRvCO4GgFch2wI4dAQPDmE2ocDw/sj+GH+PwOrDyv9I/L6bc3/CMy+VlYbmKcg28nvF77lvx/V",
-	"hQow5AvxqS6dj/S6OUrV9NUSagTpYrlvuLdwPJw3ZPcIX33HGj2mDiPSclqw1cCt33J/76AemXvRVLO5",
-	"WWtaZvSo1POgTK9DJ0o44fs1VZehDVczqddd3z1H98LPe0jSv00p63S7jxH6/q5shuGRMLAHAvaVvTIu",
-	"YmdOSD3Xpdu1QbwIIw4xRhgaIgk58hFUiJYOCRZ6iRDZyXGYGEuP3aB4H5BkAyThXkiisr+0VJmhtcHf",
-	"O22fGn+DAXztmHHWH7V0W4SO2U+g26QSrOA4Cu1JKVYIZcF9AtQwVhg9N2gtlJb28Ii314IjXK0IT+Dh",
-	"9fXVo/GNmjhYCykhl9oGqptrpcLOWndAZ4JslJqUZHgmVGIHld6EZOMbNcR5XyZLHERuZ0Lim+MK0Xde",
-	"U4k+ilJFalH6uzuhT2Mw14YfUYwGGvYqHDcfo0glt57Bo8WWh/tU2U9/fbwjefLEOoPMH3DhF7YsfMvY",
-	"vzlP/rpRJPMc/q1L0xtkEbFB2FS/fC6xxODKI5LpwkeGUKUuLQS9yAshtU4sKgdeMzuGK5Yvwo8YfiGk",
-	"wK116rfZc2AKfvKDfgLH5r7txuAnUt8/GIcufHNI+z4CaUwaBEH+0tqaWfCaTDcxPEi5cBoQZg4TtbUi",
-	"Dpy7kknvvhsVYyt5KXzuzSqcRTkLn08RmFyzjQVUxKt8eThlFr9/MvKLEc5CYCHAsUDFbcp1fyExaL0p",
-	"yBM/osEHtlH0Ftpa4WuGapj1k4YcNkE3TknqFQty7PmNghPYDhAACDHCILi3vs0TUr7PZBP3wMJSe3Uc",
-	"qnByvHU6o+YJWSMVeai0Ay/QoGQunDX71abqJprwUVNRD8t9anqftp3ux3qLlwTuyMk7wkY7MWk1KLKF",
-	"lBtYIlM2TBLYn4/Z5DyPiRyY9ZIBRFMUgxlzTAZx46ayCXxb+hI2BkExqGzql0m9ppXMBEpuz+Ems45/",
-	"1KW7yUbxBxoTfhi0pXQ3GTzURbis8oge+/eNZ1FdOIE4VTxp8jMBM7hlcPyCeemoAH1AecsUZ4ZD/V18",
-	"EAwbbGR97NM2sUK5GdcSg4r+wySMcQr99SKe0NVy42GzHdFLg+nbeK+0mXytLcbnTpIIXszWJ0xtmt7x",
-	"BLg0CnkK4VqHh+HOrUGPDExtHo1h4h/RdrjW0S+0kFqkULksPfVxYVXMVaHUs0Ae81LYKrRonGQ2AmK1",
-	"V3nbBtxt8KZLli/wJBYaPe0WDTnLF/4esg3nkTERvcg4abb7ctVltet3BVzwlbAxu3IpMPR1PyEW24SB",
-	"iqYDJNE2dvLOv+nbOl9OXl5V2N1YAy2vs/ON99LFeCv7m5VgqWzt7H/vFX4pwqbfyyOPagzN0bVuK1Xn",
-	"UX7W09RZqy+3d3l9ukVSl6jt+9X3dPbUfyX/Nz5+GrhJ3uO16qJ3uOfyPy2SjzuDuvQKx8ioeq2NgqR6",
-	"dHs32tMOYak9jLyiGHX31hcCaX8hju2QVtgtq7sh17gaexjxb98J2tUk/FP1xJPosC/Usq/9NcSTizeT",
-	"k3fxvzsOb3F+48b6Ien2HB1UKfc76k8d3bXvZMkYXqcMKWMtXccy1D1sp0EruQFCeK3QX6Qe92ctIX1p",
-	"KdfClaih9s37NOYe/VvdweuxrW+ICAvhppj/Rylfq/3j+vUrel7xr6qjUK3q2zrZs0xWugVJ5cISqeVE",
-	"GCN7fXJ2Rm9sKDzdor7h+o173eLoxlKwkQ3NJTJN+B8zwtB9PabGne79R5l5aQwtfzV833tfmzteFb/3",
-	"Pvf2ZfberI5NsbSc322v25fHYkvdvpb3Mbg02qYIo4zxpVABsOLUnZtpyb22WYRHemnrraUinKPDZ6jh",
-	"sLujHzxRT5Oqnq0+Bu1O96w0/p8IdD2tPzlChYbJ5plPPV+w+93t3X8CAAD//3wQuThmOgAA",
+	"H4sIAAAAAAAC/+xba28bN9b+KwfzvkASQJbdJtsP/uY6Tqrd3BAnCyxiI6WGRxIbipyQHMtq4f++OLzM",
+	"RTOjy8butuh+s2Y4PIfn8vA5h/RvWa6XhVaonM1Of8tsvsAl838+R4kOPxim7AzNe/xaonX0ojC6QOME",
+	"+mE8DGP2S/hlcyMKJ7TKTjMxA7dAQOXMGhQit+A0TBHCRxy0AaXdCIQCxrmgz2hEzlSOUgo1B+Hg8XQN",
+	"HGeslA5mTFp8ko0yty4wO82mWktkKrsbZTYXOXMf9BdUg5oINUfrtAFhIddqJualQU4iS4twceteSj0t",
+	"7SWaG5EjzLQBFw0wArcQFlDxQgvl4nIYXObinDlwXm6ll3VGqDmplb6f8B6tOOigWBoFbsEc2IUuJSdD",
+	"RUsg7059N8oMfi2FQZ6dfmrKua7G6ukvmDtSY9ObttDKYted1jFX2q6qb3AF4d2myuNDV52UAMGBzWaY",
+	"u29f3oUx2nRXk2vu19jRb4nWsnnfuw25foZ6fJ/sF1pyNG+iqPZaGSzRLTQH4XAJ4d0UrTdgePPIgmJL",
+	"BKY4hOzLRpurWAjJTQjrbtzT171rLJhb9L8wesqmcv2cOWbR9U27YQUvI844qvXpTtVnn5fofjR6ZTEO",
+	"Gg6+mbek/5Ps5f/4f4Oz7DT7v+MaqI4jSh03LH9XCWbGsLX/rR2TPeFHj0GVyykaiuUolMJ4ps2Suew0",
+	"K4VydUgK5XCOpmOVpG4SNbD4i1tnWO70lqwLodCTdq+EdSnhlugYZ44BhgkJLGN0kX9aiCZUC++y0X4G",
+	"fe2nmzhcfoNB02J22q8xcJv9doPWnoolDLHjHt1qzNo//pJm/Qa761lOw8APgxWDaBDH7wS8mOpxeJ9L",
+	"3roFmp+QSbcYdgkSIPu/0sbO5Lu20zp7xqagob3osrUPpRgf79xD4nyJKlymn/Ow6Yefgyv+JxortBpe",
+	"8k0Y0NU3frmfwh3h77R1FXIOkDBWOn1m8oW46dmDVgsk/Ynl0DgWxnlVeJh3DM8jvxIWPrz/eNFLsAh/",
+	"SJGeRGuiU1xlmrqPHZQWzQBRo0+DewKl8hyMwE7NQSuY4oLJWZJB8+z0eqV2U+71LkMfyo/IBAP8CM4Z",
+	"KU7aeqppUXGgZPeUAqYs/0KP/YLE4WyKPlPia9kgkTWvjF6oX/2ip+NvJVst2OtYaLp2aD8kRK62VKHc",
+	"D896cTd8EOf0Guz12UzIATlPv9/ywbCcgc+GqWIToVCVSzLdigmK1ax2mgk/Z0IJu/BMd8ZEYPRNdi/U",
+	"DZOCxyBq2H0oDPZ2YaVmny8/WjQTNdM9CL5kQvauGm8LYdB+Zq5lQs4cHjnht4/ONzO2FHL9eXB7mosb",
+	"VMOvpZ7PkX8WB3Ngg8HZnyn3twzTFB2974yW2KYEQztXRZRsGey700v1srq+oXkwL41w60vajFNFo78I",
+	"PCsDtSd7xEdZskLWRkVWiH8gsZE7irHg6DaCvEfr4OzdxENtrpfLUhH+Cg+3boUYuOQk1c4fJ56AVL8J",
+	"wAjSbKiax0CQtPGwMS9aWAm38HNevD6K9XP18ZWiz0kdJqVe2XZ5rGce0kZ+J1syJ/JeWuwJUkDjBLNf",
+	"SzQCA/UTjnydRdHVQs7eTbJRvY1n341PxifkT12gYoXITrOn45Px01gJeX8c50xKWiz9mIdiirLI248S",
+	"lRjseRpDHxq2ROdZ5qdNT7zQBhZMcd/5oHWz0i20Eb8Gb1AtCgZzFDfIYWb00g96O3l+DoXRN4J7x/ug",
+	"oOWu65iIZWwde86UuJUUbupWKe7D5Pzy/QuS6dAbfEAqueAwsdc0OOy93rxPT77vBqxfcLI72DLP0dpZ",
+	"KbNRtkCWKkipQxB3vzfIhcHcwcf3r7Jt2lDOPDs5CXmnHKqQ0njrjgvJAhht+Xq0Ve+wCwCnjVtDgn/v",
+	"Y20gmO5ulP3t/uRPlCMMlHCJ5gYNhKZJE2iy00/XBF/LJTPrTY0pc9ic4pb45gKVizCRXdMcx7xuJxQ6",
+	"sNS2/HODzCGwipWgxCUqR9VqzEWfuIQbibyQbcI7ytx2ZkWydq6VM1pK2sgok1MvIsQdWvej5usNG7Ki",
+	"kFH741+s3rDktpqvh47ftWGdYvxuI46/73jxnjSIPLXH23FILDcIPxqZcr+BPYnBayqDtEKqvWt9ylIB",
+	"9HllhMPs+q4Vc8GJwEDhKkVKI/TSk1bMHU99g6mBwZtbnDMCY9ET2jZgnSlzVxpMXNlTECBk3yPUQkfr",
+	"BVHKtSUe3IH2PkCMDbRhPGyr/Y65RdIuar3WJayYcr6R7nXopfND4ueYbRM3x9QuIZAv2Fwob4P9mmPD",
+	"Qi/Fr9sEv+m2aKBArwDuJfr6AdNtsH3ZkwipXRc7g42Mk2swMQj5+KHTj2b/7r5m/6gSC0EOzK/nFHxI",
+	"UjSDsKC0C2SNWIk2VWk+gsaPNDBQXhDqoTY3GzY37NvcBpHIIOObQPQSCYXkhkudBga2wFzMRF6hRT86",
+	"Yer87gdM7IYJyaYSux3ebc3dLlpVHecar5p96NdV33UvyPofZvwnmNHt+vcE7dmmx7WxNU4QfCT0+PZI",
+	"3hJcjQCuQzaEcOiNHu1T5YSz04erdcL8f4UCJ6z0z1jibGr+ZyhyamW1gXkKsq2lzsKffuxGdaECDPme",
+	"xFSXzkd63SfWBaqLJdQI0sVyf/bQwvFw9JI9IHz1nfD0mDqMSMtpwVYDt37PSqODemTuRVPN5mataZnR",
+	"o1LPgzK9Dp0o4YRvXVUNlzZczaRedX33Et0rP+8+Sf8+pazT7ZZOOAJxZTMMD4SBHRCwqwMg4yK25oTU",
+	"c126bRvEqzBiH2OEoSGSkCMfQYVo6bxkoZcIkZ0chomxCtsOir83NW1ZHRUPpNmitcHfW22feqCDAXzp",
+	"mHHWnzp1u6WO2S+g26QSrOA4Cp1aKW4QyoL7BKhhrDB6btBaKC3t4RFvLwVHuLghPIHHl5cXT8ZXauJg",
+	"JaSEXGobqG6ulQo7a90MngmyUerXkuGZUIkdVHoTko2v1BDnfZ0ssRe5nQmJ7w6ryT94TWWsfmJxblH6",
+	"a0yhZWUw14YfUJcHGvYmnLwfokglt57Bo8WGh/tU2U1/fbwjefLIOoPMn/XhLVsWvnvu35wmf10pknkK",
+	"/9Kl6Q2yiNhUBsb65WuJJQZXHpBMZz4yhCp1aSHoRV4IqXVkUTnwmtkxXLB8EX7E8AshBW6lU+vRngJT",
+	"8LMf9DM4NvcdSAY/k/r+wTgcSDSHtK9mkMakQRDk7++tmAWvyXQdw4OUCwcjYeYwUVsr4sC5K5n07rtS",
+	"MbaSl8Ln3qzCWZSz8PkUgckVW1tARbzKl4dTZvGHZyO/GOEsBBYCHAtU3KZc93czg9brgjzxExp8ZBtF",
+	"b6GtFb5mqIZZP2nIYRN045SkXrEgx55eKTiCzQABgBAjDIJ764tNIeX7TDZxjywstVfHoQqH6BsHVWqe",
+	"kDVSkcdKO/ACDUrmwrG7X22qbqIJnzQV9bDcp6b3advpfqy3eEngjpy8I2y0E5NWgyJbSLmGJTJlwySB",
+	"/fmYTc7zmMiBWS8ZQDRFMZgxx2QQN24qm8C3pS9hYxAUg8qm1qHUK1rJTKDk9hSuMuv4Z126q2wUf6Ax",
+	"4YdBW0p3lcFjXYR7O0/osX/feBbVhSOIU8VDNz8TMIMbBsdbzEtHBegjylumODMc6u/ig2DYYCPrY5+2",
+	"iRuU63EtMajoP0zCGKfQXy3iYWUtN5672xG9NJi+jVdsm8nX2mJ87iSJ4MVsfMLUuukdT4BLo5CnEK51",
+	"eByuHxv0yMDU+skYJv4RbYcrHf1CC6lFCpXL0lMfF1bFXBVKPQvkMS+FrUKLxklmIyBWe5W3bcDdBm86",
+	"Z/kCj2Kh0dNu0ZCzfOGvZNuNbp9IQDzOtt8zO692/a6AM34jbMyuXAoMLe4viMUmYaCiaQ9JtI0dffBv",
+	"+rbO15PXFxV2N9ZAy+vsfOOddDFeUL+3EiyVrT3tWLwtwqb/7S3OObrWxa3qaM7Pepw6a/U9/y6vTxdq",
+	"6hK1fdX8gY7h+v874Xc+iRu4VN/jterOe7jy818tkg87jjv3CsfIqHqtjYKkenR9N9rRDmGpPYy8ohh1",
+	"99YXAml/IY7tkFbYLau7Ide4Jbwf8W9fj9rWJPxL9cST6LAv1LIv/Y3Mo7N3k6MP8R9d9m9x3nNjfZ90",
+	"e4kOqpT7A/WnDu7ad7JkDG9ThpSxlq5jGeoettOglVwDIbxW6O+Uj/uzlpC+tJRr4XbYUPvmYxrzgP6t",
+	"riP22DadIlYniLFW+/vl2zf0vOJfVUehWtX9OtmzTFaGw08uLJFaToQxstdnJyf0xobC0y3qy7733OsW",
+	"BzeWgo1sPJFVMx3+3Y4wdFePqXG9ffdRZl4aQ8u/Gb76vqvNHW/NP3ife/Nef29Wx6ZYWs4fttfty2Ox",
+	"oW5fy/sQXBptUoRRxvhSqABYcerOJb3kXtsswiO9tPXWUhHO0f4z1HDY3dH3nqinSVXPVh+Ddqd7URr/",
+	"/xS6ntafHKFCw2TzzKeeL9j97vru3wEAAP//3grhNXE7AAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/webserver/api.gen.go
+++ b/internal/webserver/api.gen.go
@@ -772,6 +772,26 @@ func (response DatasetControllerIngestDataset400TextResponse) VisitDatasetContro
 	return err
 }
 
+type DatasetControllerIngestDataset401TextResponse string
+
+func (response DatasetControllerIngestDataset401TextResponse) VisitDatasetControllerIngestDatasetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(401)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
+type DatasetControllerIngestDataset500TextResponse string
+
+func (response DatasetControllerIngestDataset500TextResponse) VisitDatasetControllerIngestDatasetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(500)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
 type DatasetControllerBrowseFilesystemRequestObject struct {
 	Params DatasetControllerBrowseFilesystemParams
 }
@@ -1532,63 +1552,64 @@ func (sh *strictHandler) OtherControllerGetVersion(ctx *gin.Context) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xba28bN9b+KwfzvkASQJbdJtsP/uY6Tqrd3BAnCyxiI6WGRxIbipyQHMtq4f++OLzM",
-	"RTOjy8butuh+s2Y4PIfn8vA5h/RvWa6XhVaonM1Of8tsvsAl838+R4kOPxim7AzNe/xaonX0ojC6QOME",
-	"+mE8DGP2S/hlcyMKJ7TKTjMxA7dAQOXMGhQit+A0TBHCRxy0AaXdCIQCxrmgz2hEzlSOUgo1B+Hg8XQN",
-	"HGeslA5mTFp8ko0yty4wO82mWktkKrsbZTYXOXMf9BdUg5oINUfrtAFhIddqJualQU4iS4twceteSj0t",
-	"7SWaG5EjzLQBFw0wArcQFlDxQgvl4nIYXObinDlwXm6ll3VGqDmplb6f8B6tOOigWBoFbsEc2IUuJSdD",
-	"RUsg7059N8oMfi2FQZ6dfmrKua7G6ukvmDtSY9ObttDKYted1jFX2q6qb3AF4d2myuNDV52UAMGBzWaY",
-	"u29f3oUx2nRXk2vu19jRb4nWsnnfuw25foZ6fJ/sF1pyNG+iqPZaGSzRLTQH4XAJ4d0UrTdgePPIgmJL",
-	"BKY4hOzLRpurWAjJTQjrbtzT171rLJhb9L8wesqmcv2cOWbR9U27YQUvI844qvXpTtVnn5fofjR6ZTEO",
-	"Gg6+mbek/5Ps5f/4f4Oz7DT7v+MaqI4jSh03LH9XCWbGsLX/rR2TPeFHj0GVyykaiuUolMJ4ps2Suew0",
-	"K4VydUgK5XCOpmOVpG4SNbD4i1tnWO70lqwLodCTdq+EdSnhlugYZ44BhgkJLGN0kX9aiCZUC++y0X4G",
-	"fe2nmzhcfoNB02J22q8xcJv9doPWnoolDLHjHt1qzNo//pJm/Qa761lOw8APgxWDaBDH7wS8mOpxeJ9L",
-	"3roFmp+QSbcYdgkSIPu/0sbO5Lu20zp7xqagob3osrUPpRgf79xD4nyJKlymn/Ow6Yefgyv+JxortBpe",
-	"8k0Y0NU3frmfwh3h77R1FXIOkDBWOn1m8oW46dmDVgsk/Ynl0DgWxnlVeJh3DM8jvxIWPrz/eNFLsAh/",
-	"SJGeRGuiU1xlmrqPHZQWzQBRo0+DewKl8hyMwE7NQSuY4oLJWZJB8+z0eqV2U+71LkMfyo/IBAP8CM4Z",
-	"KU7aeqppUXGgZPeUAqYs/0KP/YLE4WyKPlPia9kgkTWvjF6oX/2ip+NvJVst2OtYaLp2aD8kRK62VKHc",
-	"D896cTd8EOf0Guz12UzIATlPv9/ywbCcgc+GqWIToVCVSzLdigmK1ax2mgk/Z0IJu/BMd8ZEYPRNdi/U",
-	"DZOCxyBq2H0oDPZ2YaVmny8/WjQTNdM9CL5kQvauGm8LYdB+Zq5lQs4cHjnht4/ONzO2FHL9eXB7mosb",
-	"VMOvpZ7PkX8WB3Ngg8HZnyn3twzTFB2974yW2KYEQztXRZRsGey700v1srq+oXkwL41w60vajFNFo78I",
-	"PCsDtSd7xEdZskLWRkVWiH8gsZE7irHg6DaCvEfr4OzdxENtrpfLUhH+Cg+3boUYuOQk1c4fJ56AVL8J",
-	"wAjSbKiax0CQtPGwMS9aWAm38HNevD6K9XP18ZWiz0kdJqVe2XZ5rGce0kZ+J1syJ/JeWuwJUkDjBLNf",
-	"SzQCA/UTjnydRdHVQs7eTbJRvY1n341PxifkT12gYoXITrOn45Px01gJeX8c50xKWiz9mIdiirLI248S",
-	"lRjseRpDHxq2ROdZ5qdNT7zQBhZMcd/5oHWz0i20Eb8Gb1AtCgZzFDfIYWb00g96O3l+DoXRN4J7x/ug",
-	"oOWu65iIZWwde86UuJUUbupWKe7D5Pzy/QuS6dAbfEAqueAwsdc0OOy93rxPT77vBqxfcLI72DLP0dpZ",
-	"KbNRtkCWKkipQxB3vzfIhcHcwcf3r7Jt2lDOPDs5CXmnHKqQ0njrjgvJAhht+Xq0Ve+wCwCnjVtDgn/v",
-	"Y20gmO5ulP3t/uRPlCMMlHCJ5gYNhKZJE2iy00/XBF/LJTPrTY0pc9ic4pb45gKVizCRXdMcx7xuJxQ6",
-	"sNS2/HODzCGwipWgxCUqR9VqzEWfuIQbibyQbcI7ytx2ZkWydq6VM1pK2sgok1MvIsQdWvej5usNG7Ki",
-	"kFH741+s3rDktpqvh47ftWGdYvxuI46/73jxnjSIPLXH23FILDcIPxqZcr+BPYnBayqDtEKqvWt9ylIB",
-	"9HllhMPs+q4Vc8GJwEDhKkVKI/TSk1bMHU99g6mBwZtbnDMCY9ET2jZgnSlzVxpMXNlTECBk3yPUQkfr",
-	"BVHKtSUe3IH2PkCMDbRhPGyr/Y65RdIuar3WJayYcr6R7nXopfND4ueYbRM3x9QuIZAv2Fwob4P9mmPD",
-	"Qi/Fr9sEv+m2aKBArwDuJfr6AdNtsH3ZkwipXRc7g42Mk2swMQj5+KHTj2b/7r5m/6gSC0EOzK/nFHxI",
-	"UjSDsKC0C2SNWIk2VWk+gsaPNDBQXhDqoTY3GzY37NvcBpHIIOObQPQSCYXkhkudBga2wFzMRF6hRT86",
-	"Yer87gdM7IYJyaYSux3ebc3dLlpVHecar5p96NdV33UvyPofZvwnmNHt+vcE7dmmx7WxNU4QfCT0+PZI",
-	"3hJcjQCuQzaEcOiNHu1T5YSz04erdcL8f4UCJ6z0z1jibGr+ZyhyamW1gXkKsq2lzsKffuxGdaECDPme",
-	"xFSXzkd63SfWBaqLJdQI0sVyf/bQwvFw9JI9IHz1nfD0mDqMSMtpwVYDt37PSqODemTuRVPN5mataZnR",
-	"o1LPgzK9Dp0o4YRvXVUNlzZczaRedX33Et0rP+8+Sf8+pazT7ZZOOAJxZTMMD4SBHRCwqwMg4yK25oTU",
-	"c126bRvEqzBiH2OEoSGSkCMfQYVo6bxkoZcIkZ0chomxCtsOir83NW1ZHRUPpNmitcHfW22feqCDAXzp",
-	"mHHWnzp1u6WO2S+g26QSrOA4Cp1aKW4QyoL7BKhhrDB6btBaKC3t4RFvLwVHuLghPIHHl5cXT8ZXauJg",
-	"JaSEXGobqG6ulQo7a90MngmyUerXkuGZUIkdVHoTko2v1BDnfZ0ssRe5nQmJ7w6ryT94TWWsfmJxblH6",
-	"a0yhZWUw14YfUJcHGvYmnLwfokglt57Bo8WGh/tU2U1/fbwjefLIOoPMn/XhLVsWvnvu35wmf10pknkK",
-	"/9Kl6Q2yiNhUBsb65WuJJQZXHpBMZz4yhCp1aSHoRV4IqXVkUTnwmtkxXLB8EX7E8AshBW6lU+vRngJT",
-	"8LMf9DM4NvcdSAY/k/r+wTgcSDSHtK9mkMakQRDk7++tmAWvyXQdw4OUCwcjYeYwUVsr4sC5K5n07rtS",
-	"MbaSl8Ln3qzCWZSz8PkUgckVW1tARbzKl4dTZvGHZyO/GOEsBBYCHAtU3KZc93czg9brgjzxExp8ZBtF",
-	"b6GtFb5mqIZZP2nIYRN045SkXrEgx55eKTiCzQABgBAjDIJ764tNIeX7TDZxjywstVfHoQqH6BsHVWqe",
-	"kDVSkcdKO/ACDUrmwrG7X22qbqIJnzQV9bDcp6b3advpfqy3eEngjpy8I2y0E5NWgyJbSLmGJTJlwySB",
-	"/fmYTc7zmMiBWS8ZQDRFMZgxx2QQN24qm8C3pS9hYxAUg8qm1qHUK1rJTKDk9hSuMuv4Z126q2wUf6Ax",
-	"4YdBW0p3lcFjXYR7O0/osX/feBbVhSOIU8VDNz8TMIMbBsdbzEtHBegjylumODMc6u/ig2DYYCPrY5+2",
-	"iRuU63EtMajoP0zCGKfQXy3iYWUtN5672xG9NJi+jVdsm8nX2mJ87iSJ4MVsfMLUuukdT4BLo5CnEK51",
-	"eByuHxv0yMDU+skYJv4RbYcrHf1CC6lFCpXL0lMfF1bFXBVKPQvkMS+FrUKLxklmIyBWe5W3bcDdBm86",
-	"Z/kCj2Kh0dNu0ZCzfOGvZNuNbp9IQDzOtt8zO692/a6AM34jbMyuXAoMLe4viMUmYaCiaQ9JtI0dffBv",
-	"+rbO15PXFxV2N9ZAy+vsfOOddDFeUL+3EiyVrT3tWLwtwqb/7S3OObrWxa3qaM7Pepw6a/U9/y6vTxdq",
-	"6hK1fdX8gY7h+v874Xc+iRu4VN/jterOe7jy818tkg87jjv3CsfIqHqtjYKkenR9N9rRDmGpPYy8ohh1",
-	"99YXAml/IY7tkFbYLau7Ide4Jbwf8W9fj9rWJPxL9cST6LAv1LIv/Y3Mo7N3k6MP8R9d9m9x3nNjfZ90",
-	"e4kOqpT7A/WnDu7ad7JkDG9ThpSxlq5jGeoettOglVwDIbxW6O+Uj/uzlpC+tJRr4XbYUPvmYxrzgP6t",
-	"riP22DadIlYniLFW+/vl2zf0vOJfVUehWtX9OtmzTFaGw08uLJFaToQxstdnJyf0xobC0y3qy7733OsW",
-	"BzeWgo1sPJFVMx3+3Y4wdFePqXG9ffdRZl4aQ8u/Gb76vqvNHW/NP3ife/Nef29Wx6ZYWs4fttfty2Ox",
-	"oW5fy/sQXBptUoRRxvhSqABYcerOJb3kXtsswiO9tPXWUhHO0f4z1HDY3dH3nqinSVXPVh+Ddqd7URr/",
-	"/xS6ntafHKFCw2TzzKeeL9j97vru3wEAAP//3grhNXE7AAA=",
+	"H4sIAAAAAAAC/+xbW28bt5f/KgezCyQBZNltsn3wm+s4qXZzQ5wssIiNlBoeSWwockJypKiFv/vi8DIX",
+	"zYwuG7vbov83zQzJc3guv3Mh9UeW62WhFSpns/M/MpsvcMn8z+co0eEHw5SdoXmPX0u0jj4URhdonEA/",
+	"jIdhzH4JTzY3onBCq+w8EzNwCwRUzmxAIXILTsMUIUzioA0o7UYgFDDOBU2jETlTOUop1ByEg8fTDXCc",
+	"sVI6mDFp8Uk2ytymwOw8m2otkansbpTZXOTMfdBfUA1yItQcrdMGhIVcq5mYlwY5kSwtwtU391LqaWmv",
+	"0axEjjDTBlwUwAjcQlhAxQstlIvbYXCdi0vmwHm6FV/WGaHmxFaaP+E9XHHQgbE0CtyCObALXUpOgoqS",
+	"QN5d+m6UGfxaCoM8O//UpHNbjdXT3zB3xMa2Nm2hlcWuOq1jrrRdVt/gGsK3bZbHx+46MQGCA5vNMHff",
+	"v70rY7Tp7ibX3O+xw98SrWXzvm9bdP0K9fg+2i+05GjeRFLtvTJYoltoDsLhEsK3KVovwPDlkQXFlghM",
+	"cQjel422d7EQkptg1l27p9m9eyyYW/R/MHrKpnLznDlm0fUtuyUFTyOuOKr56S7VJ5+X6H42em0xDho2",
+	"vpmXpP9J8vI//t3gLDvP/u20BqrTiFKnDcnfVYSZMWzjn7Vjssf86DWocjlFQ7YciZIZz7RZMpedZ6VQ",
+	"rjZJoRzO0XSkkthNpAY2f/XNGZY7vcPrgin0uN0rYV1yuCU6xpljgGFBAstoXaSfFqIJ1cK7bHSYQF/7",
+	"5SYOl98h0LSZvfJrDNwlv/2gdSBjCUPsuIe3GrMOt7/EWb/A7nq20xDww2DFIBrE8XsBL7p6HN6nkrdu",
+	"geYXZNIthlWCBMj+VwrsTL5rK60TM7YJDcWi61YcSjY+3htD4nopVbhOj/MQ9MPj4I7/G40VWg1veRUG",
+	"dPmNMw9juEP8nbauQs6BJIyVTl+YfCFWPTFovUDin7IcGsfCOM8KD+uO4XnMr4SFD+8/XvUmWIQ/xEiP",
+	"ozXRKe4yLd2XHZQWzUCiRlODekJK5XMwAjs1B61gigsmZ4kGrbNX6xXbTbq3+wR9bH5EIhjIj+CSEePE",
+	"rU81LSoO5Ow+pYApy7/Qa78hcXw2RdOU+Fo2ksg6r4xaqD/9pqfj7022WrDXkdB049B+SIhchVSh3E/P",
+	"enE3TIhreg4OmjYTcoDO0x93TBimMzBtOFVsIhSqckmiWzNBtprVSjPhcSaUsAuf6c6YCBl9M7sXasWk",
+	"4NGIGnIfMoODVVix2afLjxbNRM10D4IvmZC9u8ZvhTBoPzPXEiFnDk+c8OGjM2fGlkJuPg+Gp7lYoRr+",
+	"LPV8jvyzODoHNhiU/Zl8f8cwTdbR+81oie2UYChyVYmSLYN892qp3lZXN7QO5qURbnNNwThVNPqLwIsy",
+	"pPYkj/gqS1LI2qjICvFfSNnIHdlYUHQbQd6jdXDxbuKhNtfLZakIf4WHW7dGDLnkJNXOHyc+AameCcAI",
+	"0myomsdAkLT1srEuWlgLt/BrXr0+ifVzNflG0XRih0mp17ZdHuuZh7SRj2RL5kTemxb7BCmgcYLZryUa",
+	"gSH1E450nUXS1UYu3k2yUR3Gsx/GZ+Mz0qcuULFCZOfZ0/HZ+GmshLw+TnMmJW2WHuahmCIv8vIjR6UM",
+	"9jKNoYmGLdH5LPPTtiZeaAMLprjvfNC+WekW2ojfgzaoFgWDOYoVcpgZvfSD3k6eX0Jh9Epwr3hvFLTd",
+	"TW0TsYytbc+ZEncmhdu8VYx7M7m8fv+CaDr0Ah+gSio4juwtDQ6x14v36dmPXYP1G05yB1vmOVo7K2U2",
+	"yhbIUgUpdTDi7nyDXBjMHXx8/yrbxQ35zLOzs+B3yqEKLo3f3GkhWQCjHbNHO/kOUQA4BW4NCf69jrWB",
+	"ILq7UfYf90d/ohxhoIRrNCs0EJomTaDJzj/dEnwtl8xstjkmz2FzslvKNxeoXISJ7JbWOOV1O6HQIUtt",
+	"0780yBwCq7ISlLhE5ahajb7oHZdwIyUvJJvwjTy37VkxWbvUyhktJQUy8uTUiwh2h9b9rPlmS4asKGTk",
+	"/vQ3q7ckuavm60nH79qwTjZ+t2XHP3a0eE8cxDy1R9txSCw3CD8annK/hj2JxmuSQGj1H+5r9Y8qwSBy",
+	"YH4LcAIbXQLX6pGDBVtheh/z6GRg2gAhNQjFfeipGiMNTv9sB2vH8E9ZKgc/r41wmN3etTwwmDQwULhO",
+	"22o4YnrT8sDTqW+3NSLSdsB3RmAsAUMTC6wzZe5Kg6ly8AmZl94Bjhf6ey8owd5Yqgo6ga4vPMR24nB0",
+	"aLP9jjQZuYtckxGsmXL+WMHz0FvcDJGfY7aL3BxT82jmDWkulJfBYa3CYaLX4vddhN90G1ZQoGcADyJ9",
+	"+4DgM9jM7XGH1LyMfdIG/sgNmGiEfPx3B6Nz8CYZgMaC0i6krpSjaVM1KkbQeEgDQwEAQj0UEtmARHgU",
+	"EhlkfBuIXiKhkNxSqdPAwBaYi5nIK7ToRydMffDDgImtmJBsKrHb797V6u6iVdV/r/Gq2ZV/XXWhD4Ks",
+	"f2HG/wUzumcgPUZ7sa1xbWyNEwQfCT2+35J3GFfDgGuTDSYcOsUnh9R84ST54Sq/sP4/odwLO/07Fnzb",
+	"nP8dSr6aWW1gnoxsZ+G38GdB+1FdqABDvkMz1aXzll53zXWB6moJNYJ0sdyfxLRwPBxEZQ8IX33nXT2i",
+	"DiPSdlqw1cCth011duiVUI/EvWiy2QzWmrYZNSr1PDDTq9CJEk74Rl7VfmrD1UzqdVd3L9G98use4vTv",
+	"k8s63W5whQMhVzbN8EgY2AMB+/ohMm5ip09IPdel2xUgXoURhwgjDA2WhBz5CCpES6dHC71EiNnJcZgY",
+	"q7DdoPhnp6YtqaPiIWm2aG3Q907Zp47woAFfO2ac9Wdw3d6xY/YL6HZSCVZwHIW+tRQrhLLg3gFqGCuM",
+	"nhu0FkpLMTzi7bXgCFcrwhN4fH199WR8oyYO1kJKyKW2IdXNtVIhstat8ZkgGaXuNQmeCZWyg4pvQrLx",
+	"jRrKeV8nSRyU3M6ExHfH1eQfPKcyVj+xOLco/aWu0MAzmGvDj6jLQxr2JtxDOIaRim69gkeLLQ33sbI/",
+	"/fX2jqTJE+sMMn/yid/YsvBnCf7LedLXjSKa5/A/ujS9RhYRm8rAWL98LbHEoMojnOnCW4ZQpS4tBL5I",
+	"C8G1TiwqB54zO4Yrli/CQzS/YFLg1jo1Yu05MAW/+kG/gmNz349l8Cux71+Mw/FMc0j7ogpxTBwEQv42",
+	"45pZ8JxMN9E8iLlwTBRWDgu1uaIcOHclk159NyraVtJSmO7FKpxFOQvTpwhMrtnGAirKq3x5OGUWf3o2",
+	"8psRzkLIQoBjgYrb5Ov+pmrgelOQJn5Bg49so+gttLXC1wzVMOsXDT5sAm+cnNQzFujY8xsFJ7BtIAAQ",
+	"bIRBUG99zSu4fJ/IJu6RhaX27DhU4UrB1rGdmidkjanIY6UdeIIGpW+Cxi5pVd1EET5pMuphuY9Nr9O2",
+	"0v1YL/GSwB05aUfYKCcmrQZFspByA0tkyoZFQvbnbTYpz2MiB2Y9ZQDRJMVgxhyTgdy4yWwC3xa/hI2B",
+	"UDQqm1qHUq9pJzOBkttzuMms45916W6yUXxAY8KDQVtKd5PBY12EW0xP6LX/3ngX2YUTiEvFI0i/EjCD",
+	"WwLHb5iXjgrQR+S3THFmONTz4osg2CAj622fwsQK5WZcUwws+omJGONk+utFPLqt6cZbCHZEHw2mufHC",
+	"cdP5WiHG+06iCJ7M1hSmNk3t+AS4NAp5MuGah8fhMrZBjwxMbZ6MYeJfUThc66gX2khNUqhclj71cWFX",
+	"zFWm1LNBHv1S2Mq0aJxkNgJiFau8bAPuNvKmS5Yv8CQWGj3tFg05yxf+grrd6vaJBMTjbPetu8sq6ncJ",
+	"XPCVsNG7cikwtLi/IBbbCQMVTQdQojB28sF/6QudryevryrsbuyBtteJfOO96WK8rn9vJVgqW3vasfit",
+	"CEH/+1ucc3Sta2zVQaVf9TR11up/PXTz+nS9qC5R2xfvH+hQsv+/Gn/yueTAXwx6tFb9AyBcgPp/LZKP",
+	"O4679AxHy6h6rY2CpHp1ezfa0w5hqT2MvEox6u6tLwRSfKEc2yHtsFtWd02ucWf6sMS/fVlsV5PwH9UT",
+	"T6RDXKhpX/v7qScX7yYnH+Lffg5vcd5zY/0Qd3uJDiqX+wv1p47u2ne8ZAxvk4eUsZaubRnqHrbToJXc",
+	"ACG8Vuhv2I/7vZaQvrTka+Gu3FD75mMa84D6rS5n9sg2nSJWJ4ixVvvP67dv6H2Vf1UdhWpX96tkn2Wy",
+	"Mhx+cmEpqeWUMMbs9dnZGX2xofB0i/rq8z33usXRjaUgIxtPZNVMhz8fEobu6zE1LvvvP8rMS2No+6vh",
+	"PwLsa3PH/xA8eJ97+18OvV4dm2JpO3/ZXrcvj8UWu30t72NwabSdIowyxpdCBcCKS3euLCb12mYRHtNL",
+	"W4eWKuEcHb5CDYfdiH7wQj1Nqnq1+hi0u9yL0vh/l+h6WX9yhAoNk80zn3q9IPe727v/DQAA//8pflDZ",
+	"fzwAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/webserver/auth.go
+++ b/internal/webserver/auth.go
@@ -156,6 +156,7 @@ func (i *IngestorWebServerImplemenation) GetCallback(ctx context.Context, reques
 	userSession.Set("name", claims.Name)
 	userSession.Set("family_name", claims.FamilyName)
 	userSession.Set("given_name", claims.GivenName)
+	userSession.Set("access_groups", claims.AccessGroups)
 	userSession.Options(sessions.Options{
 		HttpOnly: true,
 		MaxAge:   int(i.sessionDuration),

--- a/internal/webserver/claims.go
+++ b/internal/webserver/claims.go
@@ -14,6 +14,7 @@ type idTokenClaims struct {
 type keycloakClaims struct {
 	RealmAccess       rolesList            `json:"realm_access,omitempty"`
 	ResourceAccess    map[string]rolesList `json:"resource_access,omitempty"`
+	AccessGroups      []string             `json:"accessGroups,omitempty"`
 	Name              string               `json:"name,omitempty"`               // "name": "OIDC User"
 	PreferredUsername string               `json:"preferred_username,omitempty"` // "preferred_username": "oidc-user"
 	GivenName         string               `json:"given_name,omitempty"`         // "given_name": "OIDC"
@@ -44,4 +45,8 @@ func (c *keycloakClaims) GetAllResourceRoles() map[string][]string {
 		returnMap[k] = v.Roles
 	}
 	return returnMap
+}
+
+func (c *keycloakClaims) GetAccessGroups() []string {
+	return c.AccessGroups
 }

--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -17,24 +17,11 @@ import (
 	"github.com/SwissOpenEM/Ingestor/internal/transfertask"
 	"github.com/SwissOpenEM/Ingestor/internal/webserver/collections"
 	"github.com/SwissOpenEM/Ingestor/internal/webserver/globusauth"
-	"github.com/gin-contrib/sessions"
-	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 )
 
 func (i *IngestorWebServerImplemenation) DatasetControllerBrowseFilesystem(ctx context.Context, request DatasetControllerBrowseFilesystemRequestObject) (DatasetControllerBrowseFilesystemResponseObject, error) {
-	ginCtx, ok := ctx.(*gin.Context)
-	if !ok {
-		return DatasetControllerBrowseFilesystem500TextResponse("internal context error"), nil
-	}
-
-	userSession := sessions.DefaultMany(ginCtx, "user")
-	accessGroups, ok := userSession.Get("access_groups").([]string)
-	if !ok {
-		return DatasetControllerBrowseFilesystem500TextResponse("internal user session error: can't get access groups of user"), nil
-	}
-
 	// an internal function used to determine if a folder has subfolders
 	folderHasFilesOrSubFolders := func(path string) (bool, bool) {
 		folder, err := os.Open(path)
@@ -103,7 +90,7 @@ func (i *IngestorWebServerImplemenation) DatasetControllerBrowseFilesystem(ctx c
 		return DatasetControllerBrowseFilesystem500TextResponse("internal server error: " + err.Error()), nil
 	}
 
-	err = datasetaccess.CheckUserAccess(absPath, accessGroups)
+	err = datasetaccess.CheckUserAccess(ctx, absPath)
 	if errors.Is(err, &datasetaccess.AccessError{}) {
 		return DatasetControllerBrowseFilesystem401TextResponse("unauthorized: " + err.Error()), nil
 	} else if err != nil {

--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -3,6 +3,7 @@ package webserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -10,16 +11,30 @@ import (
 	"strings"
 
 	"github.com/SwissOpenEM/Ingestor/internal/core"
+	"github.com/SwissOpenEM/Ingestor/internal/datasetaccess"
 	"github.com/SwissOpenEM/Ingestor/internal/extglobusservice"
 	"github.com/SwissOpenEM/Ingestor/internal/s3upload"
 	"github.com/SwissOpenEM/Ingestor/internal/transfertask"
 	"github.com/SwissOpenEM/Ingestor/internal/webserver/collections"
 	"github.com/SwissOpenEM/Ingestor/internal/webserver/globusauth"
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/paulscherrerinstitute/scicat-cli/v3/datasetIngestor"
 )
 
 func (i *IngestorWebServerImplemenation) DatasetControllerBrowseFilesystem(ctx context.Context, request DatasetControllerBrowseFilesystemRequestObject) (DatasetControllerBrowseFilesystemResponseObject, error) {
+	ginCtx, ok := ctx.(*gin.Context)
+	if !ok {
+		return DatasetControllerBrowseFilesystem500TextResponse("internal context error"), nil
+	}
+
+	userSession := sessions.DefaultMany(ginCtx, "user")
+	accessGroups, ok := userSession.Get("access_groups").([]string)
+	if !ok {
+		return DatasetControllerBrowseFilesystem500TextResponse("internal user session error: can't get access groups of user"), nil
+	}
+
 	// an internal function used to determine if a folder has subfolders
 	folderHasFilesOrSubFolders := func(path string) (bool, bool) {
 		folder, err := os.Open(path)
@@ -75,16 +90,24 @@ func (i *IngestorWebServerImplemenation) DatasetControllerBrowseFilesystem(ctx c
 	absPath := filepath.Join(collectionPath, relPath)
 
 	// check if path is dir
-	folder, err := os.Stat(absPath)
+	err = datasetaccess.IsFolderCheck(absPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return DatasetControllerBrowseFilesystem400TextResponse("path does not exist or is invalid"), nil
-		} else {
-			return nil, err
-		}
+		return DatasetControllerBrowseFilesystem400TextResponse("path is directory check error: " + err.Error()), nil
 	}
-	if !folder.IsDir() {
-		return DatasetControllerBrowseFilesystem400TextResponse("path does not point to a folder"), nil
+
+	// dataset access checks
+	err = datasetaccess.CheckAccessIntegrity(absPath)
+	if errors.Is(err, &datasetaccess.InvalidGroupsError{}) || errors.Is(err, &datasetaccess.PathError{}) {
+		return DatasetControllerBrowseFilesystem500TextResponse("error - path access rules are invalid: " + err.Error()), nil
+	} else if err != nil {
+		return DatasetControllerBrowseFilesystem500TextResponse("internal server error: " + err.Error()), nil
+	}
+
+	err = datasetaccess.CheckUserAccess(absPath, accessGroups)
+	if errors.Is(err, &datasetaccess.AccessError{}) {
+		return DatasetControllerBrowseFilesystem401TextResponse("unauthorized: " + err.Error()), nil
+	} else if err != nil {
+		return DatasetControllerBrowseFilesystem500TextResponse("internal server error: " + err.Error()), nil
 	}
 
 	// get page values

--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -191,9 +191,24 @@ func (i *IngestorWebServerImplemenation) DatasetControllerIngestDataset(ctx cont
 	}
 
 	// check if folder exists
-	err = core.CheckIfFolderExists(folderPath)
+	err = datasetaccess.IsFolderCheck(folderPath)
 	if err != nil {
 		return DatasetControllerIngestDataset400TextResponse(fmt.Sprintf("dataset location lookup error: %s", err.Error())), nil
+	}
+
+	// dataset access checks
+	err = datasetaccess.CheckAccessIntegrity(folderPath)
+	if errors.Is(err, &datasetaccess.InvalidGroupsError{}) || errors.Is(err, &datasetaccess.PathError{}) {
+		return DatasetControllerIngestDataset500TextResponse("error - path access rules are invalid: " + err.Error()), nil
+	} else if err != nil {
+		return DatasetControllerIngestDataset500TextResponse("internal server error: " + err.Error()), nil
+	}
+
+	err = datasetaccess.CheckUserAccess(ctx, folderPath)
+	if errors.Is(err, &datasetaccess.AccessError{}) {
+		return DatasetControllerIngestDataset401TextResponse("unauthorized: " + err.Error()), nil
+	} else if err != nil {
+		return DatasetControllerIngestDataset500TextResponse("internal server error: " + err.Error()), nil
 	}
 
 	// do catalogue insertion

--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -3,8 +3,8 @@ package webserver
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -83,18 +83,12 @@ func (i *IngestorWebServerImplemenation) DatasetControllerBrowseFilesystem(ctx c
 	}
 
 	// dataset access checks
-	err = datasetaccess.CheckAccessIntegrity(absPath)
-	if errors.Is(err, &datasetaccess.InvalidGroupsError{}) || errors.Is(err, &datasetaccess.PathError{}) {
-		return DatasetControllerBrowseFilesystem500TextResponse("error - path access rules are invalid: " + err.Error()), nil
-	} else if err != nil {
-		return DatasetControllerBrowseFilesystem500TextResponse("internal server error: " + err.Error()), nil
-	}
-
 	err = datasetaccess.CheckUserAccess(ctx, absPath)
-	if errors.Is(err, &datasetaccess.AccessError{}) {
+	if _, ok := err.(*datasetaccess.AccessError); ok {
 		return DatasetControllerBrowseFilesystem401TextResponse("unauthorized: " + err.Error()), nil
 	} else if err != nil {
-		return DatasetControllerBrowseFilesystem500TextResponse("internal server error: " + err.Error()), nil
+		slog.Error("user access error", "error", err.Error())
+		return DatasetControllerBrowseFilesystem500TextResponse("internal server error: user access error"), nil
 	}
 
 	// get page values
@@ -197,18 +191,12 @@ func (i *IngestorWebServerImplemenation) DatasetControllerIngestDataset(ctx cont
 	}
 
 	// dataset access checks
-	err = datasetaccess.CheckAccessIntegrity(folderPath)
-	if errors.Is(err, &datasetaccess.InvalidGroupsError{}) || errors.Is(err, &datasetaccess.PathError{}) {
-		return DatasetControllerIngestDataset500TextResponse("error - path access rules are invalid: " + err.Error()), nil
-	} else if err != nil {
-		return DatasetControllerIngestDataset500TextResponse("internal server error: " + err.Error()), nil
-	}
-
 	err = datasetaccess.CheckUserAccess(ctx, folderPath)
-	if errors.Is(err, &datasetaccess.AccessError{}) {
+	if _, ok := err.(*datasetaccess.AccessError); ok {
 		return DatasetControllerIngestDataset401TextResponse("unauthorized: " + err.Error()), nil
 	} else if err != nil {
-		return DatasetControllerIngestDataset500TextResponse("internal server error: " + err.Error()), nil
+		slog.Error("user access error", "error", err.Error())
+		return DatasetControllerIngestDataset500TextResponse("internal server error: user access error"), nil
 	}
 
 	// do catalogue insertion

--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -119,13 +119,13 @@ func (i *IngestorWebServerImplemenation) DatasetControllerBrowseFilesystem(ctx c
 		}
 		if d.IsDir() && currPath != absPath {
 			if folderCounter >= start && folderCounter < end {
-				hasFiles, hasChildren := folderHasFilesOrSubFolders(currPath)
+				_, hasChildren := folderHasFilesOrSubFolders(currPath)
 				relativePath, _ := filepath.Rel(collectionPath, currPath)
 
 				folders[folderCounter-start].Name = d.Name()
 				folders[folderCounter-start].Path = "/" + collectionName + "/" + filepath.ToSlash(relativePath)
 				folders[folderCounter-start].Children = hasChildren
-				folders[folderCounter-start].ProbablyDataset = hasFiles
+				folders[folderCounter-start].ProbablyDataset = datasetaccess.IsDatasetFolder(currPath)
 			}
 			folderCounter++
 			return filepath.SkipDir // prevent recursing into subfolders

--- a/internal/webserver/metadata.go
+++ b/internal/webserver/metadata.go
@@ -142,10 +142,27 @@ func (i *IngestorWebServerImplemenation) ExtractMetadata(ctx context.Context, re
 	} else if err != nil {
 		return ExtractMetadatadefaultJSONResponse{
 			Body: Error{
-				Code:    "400",
+				Code:    "500",
 				Message: "internal server error: " + err.Error(),
 			},
-			StatusCode: 400}, nil
+			StatusCode: 500}, nil
+	}
+
+	err = datasetaccess.CheckUserAccess(ctx, absPath)
+	if errors.Is(err, &datasetaccess.AccessError{}) {
+		return ExtractMetadatadefaultJSONResponse{
+			Body: Error{
+				Code:    "401",
+				Message: "unauthorized: " + err.Error(),
+			},
+			StatusCode: 401}, nil
+	} else if err != nil {
+		return ExtractMetadatadefaultJSONResponse{
+			Body: Error{
+				Code:    "500",
+				Message: "internal server error: " + err.Error(),
+			},
+			StatusCode: 500}, nil
 	}
 
 	// start streaming the extraction process


### PR DESCRIPTION
This PR adds the following features:
 - Read `openem-access.yaml` files for access control
 - The file has both an `AllowedGroups` and `BlockedGroups` list for specifying access rights
 - If `AllowedGroups` is not specified on any level, then any user is allowed if none of their groups are on the `BlockedGroups` list
 - If specified, the user has to have at least one group that is listed under the `AllowedGroups` list
 - It also has a flag called `HasDatasetFolders` which is there to indicate whether the current directory contains dataset folders. It is used to determine what is likely to be considered to be a dataset in the `DatasetBrowser` endpoint
 - `Path` must be the path of the file being read, it's used as a simple integrity check (a path error is thrown if incorrect)
 - These access files are used for requests dealing with datasets: browsing,ingestion, metadata extraction
 - These files are applied recursively and the code checks rule consistency by checking the upper levels of any given path for any files named `openem-access.yaml`
   - `AccessGroups`, once specified, can only be narrowed down on lower level paths, you can't specify additional groups
   - `BlockedGroups` can only be expanded on lower levels, meaning that by specifying a list on lower levels will only add to the overall list of blocked groups
   - if a group appears in both lists, a group conflict error is thrown (Error 500 on the client side)