### PR TITLE
Fix compatibility with scicat v3

### DIFF
--- a/cmd/openem-ingestor-service/main.go
+++ b/cmd/openem-ingestor-service/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"strings"
 
 	core "github.com/SwissOpenEM/Ingestor/internal/core"
 	"github.com/SwissOpenEM/Ingestor/internal/metadataextractor"
@@ -51,6 +52,10 @@ func main() {
 	println(string(configData))
 
 	setupLogging(config.WebServer.LogLevel)
+
+	if !strings.HasSuffix(config.Scicat.Host, "v3") {
+		panic(fmt.Sprintf("Only Scicat API v3 is supported. No v3 suffix found in API path. Got '%s'", config.Scicat.Host))
+	}
 
 	ctx := context.Background()
 

--- a/internal/s3upload/httpuploader.go
+++ b/internal/s3upload/httpuploader.go
@@ -80,7 +80,10 @@ func getPresignedUrls(object_name string, part int, endpoint string, userToken s
 	}
 
 	if response.StatusCode() == http.StatusInternalServerError {
-		return "", []string{}, fmt.Errorf("%s: %s", response.JSON500.Message, *response.JSON500.Details)
+		if response.JSON500 != nil {
+			return "", []string{}, fmt.Errorf("%s: %s", response.JSON500.Message, *response.JSON500.Details)
+		}
+		return "", []string{}, fmt.Errorf("Unknown error")
 	}
 	if response.StatusCode() == http.StatusUnprocessableEntity {
 		err_string := ""


### PR DESCRIPTION
- Scicat CLI is not compatible with the Scicat API v4 at this point. This is due the following missing endpoints 

| Endpoint | Used in |
| --- |-- |
| `/users/my/self` | scicat cli: `GetUserInfoFromToken(http_client, scicatUrl, userToken)` |
| `/origdatablocks` | scicat cli: `IngestDataset(http_client, SCICAT_API_URL, metaDataMap, fileList, user)` |

v3 is enforced therefore.

- v3 requires `principalInvestigator`, however, it is not available in the frontend datasetdto so it needs to be added manually

- The metadata validation function in Scicat-cli will add metadata in some cases, for example see https://github.com/paulscherrerinstitute/scicat-cli/blob/24887a4b7048b540025257baa1ae453399f57065/datasetIngestor/checkMetadata.go#L254
