### PR TITLE
Metadata: fix race condition

### DIFF
--- a/internal/webserver/metadatatasks/logger.go
+++ b/internal/webserver/metadatatasks/logger.go
@@ -1,0 +1,16 @@
+package metadatatasks
+
+import (
+	"log/slog"
+	"sync"
+)
+
+var logger *slog.Logger
+var loggerOnce sync.Once
+
+func log() *slog.Logger {
+	loggerOnce.Do(func() {
+		logger = slog.Default().With("package", "metadatatasks")
+	})
+	return logger
+}

--- a/internal/webserver/metadatatasks/task.go
+++ b/internal/webserver/metadatatasks/task.go
@@ -29,6 +29,7 @@ func (t *ExtractionProgress) GetExtractorError() error {
 func (t *ExtractionProgress) setStdOut(output string) {
 	if !t.finished {
 		t.taskStdOut = output
+		log().Info("Metadata Extractor", "message", output)
 		t.setProgress()
 	}
 }
@@ -36,6 +37,7 @@ func (t *ExtractionProgress) setStdOut(output string) {
 func (t *ExtractionProgress) setStdErr(output string) {
 	if !t.finished {
 		t.taskStdErr = output
+		log().Error("Metadata Extractor", "error", output)
 		t.setProgress()
 	}
 }


### PR DESCRIPTION
The command completed and closed the SSE connection before all of the stdout and stderr could be forwarded