### PR TITLE
set cookies to 'SameSite: none' for cross origin requests

### DIFF
--- a/internal/webserver/auth.go
+++ b/internal/webserver/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"slices"
 	"time"
@@ -43,6 +44,7 @@ func (i *IngestorWebServerImplemenation) GetLogin(ctx context.Context, request G
 		HttpOnly: true,
 		MaxAge:   300,
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
+		SameSite: http.SameSiteNoneMode,
 	})
 	authSession.Set("state", state)
 	authSession.Set("verifier", verifier)
@@ -89,6 +91,7 @@ func (i *IngestorWebServerImplemenation) GetCallback(ctx context.Context, reques
 	authSession.Options(sessions.Options{
 		HttpOnly: true,
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
+		SameSite: http.SameSiteNoneMode,
 		MaxAge:   -1,
 	})
 	err := authSession.Save()
@@ -160,6 +163,7 @@ func (i *IngestorWebServerImplemenation) GetCallback(ctx context.Context, reques
 		HttpOnly: true,
 		MaxAge:   int(i.sessionDuration),
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
+		SameSite: http.SameSiteNoneMode,
 	})
 	err = userSession.Save()
 	if err != nil {
@@ -196,6 +200,7 @@ func (i *IngestorWebServerImplemenation) GetLogout(ctx context.Context, request 
 	userSession.Options(sessions.Options{
 		HttpOnly: true,
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
+		SameSite: http.SameSiteNoneMode,
 		MaxAge:   -1,
 	})
 	err := userSession.Save()
@@ -294,6 +299,7 @@ func (i *IngestorWebServerImplemenation) GetGlobusCallback(ctx context.Context, 
 	authSession.Options(sessions.Options{
 		HttpOnly: true,
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
+		SameSite: http.SameSiteNoneMode,
 		MaxAge:   -1,
 	})
 	err := authSession.Save()

--- a/internal/webserver/auth.go
+++ b/internal/webserver/auth.go
@@ -40,11 +40,15 @@ func (i *IngestorWebServerImplemenation) GetLogin(ctx context.Context, request G
 	}
 
 	// store state, verifier & nonce in session
+	sameSiteMode := http.SameSiteLaxMode
+	if i.secureCookies || (ginCtx.Request.TLS != nil) {
+		sameSiteMode = http.SameSiteNoneMode
+	}
 	authSession.Options(sessions.Options{
 		HttpOnly: true,
 		MaxAge:   300,
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSiteMode,
 	})
 	authSession.Set("state", state)
 	authSession.Set("verifier", verifier)
@@ -88,10 +92,14 @@ func (i *IngestorWebServerImplemenation) GetCallback(ctx context.Context, reques
 	authSession.Delete("state")
 	authSession.Delete("verifier")
 	authSession.Delete("nonce")
+	sameSiteMode := http.SameSiteLaxMode
+	if i.secureCookies || (ginCtx.Request.TLS != nil) {
+		sameSiteMode = http.SameSiteNoneMode
+	}
 	authSession.Options(sessions.Options{
 		HttpOnly: true,
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSiteMode,
 		MaxAge:   -1,
 	})
 	err := authSession.Save()
@@ -163,7 +171,7 @@ func (i *IngestorWebServerImplemenation) GetCallback(ctx context.Context, reques
 		HttpOnly: true,
 		MaxAge:   int(i.sessionDuration),
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSiteMode,
 	})
 	err = userSession.Save()
 	if err != nil {
@@ -197,10 +205,14 @@ func (i *IngestorWebServerImplemenation) GetLogout(ctx context.Context, request 
 
 	// expire session data
 	userSession := sessions.DefaultMany(ginCtx, "user")
+	sameSiteMode := http.SameSiteLaxMode
+	if i.secureCookies || (ginCtx.Request.TLS != nil) {
+		sameSiteMode = http.SameSiteLaxMode
+	}
 	userSession.Options(sessions.Options{
 		HttpOnly: true,
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSiteMode,
 		MaxAge:   -1,
 	})
 	err := userSession.Save()
@@ -296,10 +308,14 @@ func (i *IngestorWebServerImplemenation) GetGlobusCallback(ctx context.Context, 
 	// delete auth session
 	authSession.Delete("state")
 	authSession.Delete("verifier")
+	sameSiteMode := http.SameSiteLaxMode
+	if i.secureCookies || (ginCtx.Request.TLS != nil) {
+		sameSiteMode = http.SameSiteLaxMode
+	}
 	authSession.Options(sessions.Options{
 		HttpOnly: true,
 		Secure:   i.secureCookies || (ginCtx.Request.TLS != nil),
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSiteMode,
 		MaxAge:   -1,
 	})
 	err := authSession.Save()

--- a/internal/webserver/globusauth/auth.go
+++ b/internal/webserver/globusauth/auth.go
@@ -34,11 +34,15 @@ func GetRedirectUrl(ctx context.Context, globusAuthConf *oauth2.Config, secureCo
 	verifier := oauth2.GenerateVerifier()
 
 	// store state, verifier & nonce in session
+	sameSiteMode := http.SameSiteLaxMode
+	if secureCookies || (ginCtx.Request.TLS != nil) {
+		sameSiteMode = http.SameSiteNoneMode
+	}
 	authSession.Options(sessions.Options{
 		HttpOnly: true,
 		MaxAge:   300,
 		Secure:   secureCookies || (ginCtx.Request.TLS != nil),
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSiteMode,
 	})
 	authSession.Set("state", state)
 	authSession.Set("verifier", verifier)

--- a/internal/webserver/globusauth/auth.go
+++ b/internal/webserver/globusauth/auth.go
@@ -38,6 +38,7 @@ func GetRedirectUrl(ctx context.Context, globusAuthConf *oauth2.Config, secureCo
 		HttpOnly: true,
 		MaxAge:   300,
 		Secure:   secureCookies || (ginCtx.Request.TLS != nil),
+		SameSite: http.SameSiteNoneMode,
 	})
 	authSession.Set("state", state)
 	authSession.Set("verifier", verifier)

--- a/internal/webserver/globusauth/cookie.go
+++ b/internal/webserver/globusauth/cookie.go
@@ -31,11 +31,15 @@ func SetTokenCookie(ctx *gin.Context, refreshToken string, accessToken string, e
 	s.Set("refresh_token", refreshToken)
 	s.Set("access_token", accessToken)
 	s.Set("expiry", expiry.Format(time.RFC3339Nano))
+	sameSiteMode := http.SameSiteLaxMode
+	if secureCookies || (ctx.Request.TLS != nil) {
+		sameSiteMode = http.SameSiteNoneMode
+	}
 	s.Options(sessions.Options{
 		HttpOnly: true,
 		MaxAge:   int(sessionDuration),
 		Secure:   secureCookies || (ctx.Request.TLS != nil),
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSiteMode,
 	})
 	return s.Save()
 }
@@ -45,10 +49,14 @@ func DeleteTokenCookie(ctx *gin.Context, secureCookies bool) error {
 	s.Delete("access_token")
 	s.Delete("refresh_token")
 	s.Delete("expiry")
+	sameSiteMode := http.SameSiteLaxMode
+	if secureCookies || (ctx.Request.TLS != nil) {
+		sameSiteMode = http.SameSiteNoneMode
+	}
 	s.Options(sessions.Options{
 		HttpOnly: true,
 		Secure:   secureCookies || (ctx.Request.TLS != nil),
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSiteMode,
 		MaxAge:   -1,
 	})
 	return s.Save()

--- a/internal/webserver/globusauth/cookie.go
+++ b/internal/webserver/globusauth/cookie.go
@@ -2,6 +2,7 @@ package globusauth
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/gin-contrib/sessions"
@@ -34,6 +35,7 @@ func SetTokenCookie(ctx *gin.Context, refreshToken string, accessToken string, e
 		HttpOnly: true,
 		MaxAge:   int(sessionDuration),
 		Secure:   secureCookies || (ctx.Request.TLS != nil),
+		SameSite: http.SameSiteNoneMode,
 	})
 	return s.Save()
 }
@@ -46,6 +48,7 @@ func DeleteTokenCookie(ctx *gin.Context, secureCookies bool) error {
 	s.Options(sessions.Options{
 		HttpOnly: true,
 		Secure:   secureCookies || (ctx.Request.TLS != nil),
+		SameSite: http.SameSiteNoneMode,
 		MaxAge:   -1,
 	})
 	return s.Save()


### PR DESCRIPTION
This PR adds `SameSite: none` as  cookie parameter to all cookies to allow Cross Site requests.