### PR TITLE
Subpool configuration

### DIFF
--- a/cmd/openem-ingestor-app/app.go
+++ b/cmd/openem-ingestor-app/app.go
@@ -5,11 +5,15 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"strings"
 
 	core "github.com/SwissOpenEM/Ingestor/internal/core"
 	metadataextractor "github.com/SwissOpenEM/Ingestor/internal/metadataextractor"
+	"github.com/SwissOpenEM/Ingestor/internal/s3upload"
 	task "github.com/SwissOpenEM/Ingestor/internal/transfertask"
 	webserver "github.com/SwissOpenEM/Ingestor/internal/webserver"
+	"github.com/SwissOpenEM/Ingestor/internal/webserver/metadatatasks"
+	"github.com/alitto/pond/v2"
 
 	"github.com/google/uuid"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -80,18 +84,33 @@ func (b *App) beforeClose(ctx context.Context) (prevent bool) {
 // startup is called when the app starts. The context is saved
 // so we can call the runtime methods
 func (a *App) startup(ctx context.Context) {
-	a.ctx = ctx
-
-	a.extractorHandler = metadataextractor.NewExtractorHandler(a.config.MetadataExtractors)
-
-	a.taskqueue = core.TaskQueue{Config: a.config,
-		AppContext: a.ctx,
-		Notifier:   &WailsNotifier{AppContext: a.ctx},
+	totalConcurrencyLimit := a.config.Transfer.ConcurrencyLimit + a.config.WebServer.ConcurrencyLimit
+	if strings.ToLower(a.config.Transfer.Method) == "s3" {
+		totalConcurrencyLimit += a.config.Transfer.S3.PoolSize
 	}
-	a.taskqueue.Startup()
+	mainTaskPool := pond.NewPool(totalConcurrencyLimit)
+
+	s3upload.InitHttpUploaderWithPool(mainTaskPool.NewSubpool(a.config.Transfer.S3.PoolSize))
+
+	a.ctx = ctx
+	a.extractorHandler = metadataextractor.NewExtractorHandler(a.config.MetadataExtractors)
+	a.taskqueue = *core.NewTaskQueueFromPool(
+		a.ctx,
+		a.config,
+		&WailsNotifier{AppContext: a.ctx},
+		nil,
+		mainTaskPool.NewSubpool(a.config.Transfer.ConcurrencyLimit, pond.WithQueueSize(a.config.Transfer.QueueSize)),
+	)
 
 	go func(port int) {
-		ingestor, err := webserver.NewIngestorWebServer(a.version, &a.taskqueue, a.extractorHandler, a.config.WebServer)
+		extractorPool := metadatatasks.NewTaskPoolFromPool(
+			a.extractorHandler,
+			mainTaskPool.NewSubpool(
+				a.config.WebServer.MetadataExtJobsConf.ConcurrencyLimit,
+				pond.WithQueueSize(a.config.WebServer.MetadataExtJobsConf.QueueSize),
+			),
+		)
+		ingestor, err := webserver.NewIngestorWebServer(a.version, &a.taskqueue, extractorPool, a.config.WebServer)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/openem-ingestor-app/frontend/wailsjs/runtime/runtime.d.ts
+++ b/cmd/openem-ingestor-app/frontend/wailsjs/runtime/runtime.d.ts
@@ -134,7 +134,7 @@ export function WindowIsFullscreen(): Promise<boolean>;
 
 // [WindowSetSize](https://wails.io/docs/reference/runtime/window#windowsetsize)
 // Sets the width and height of the window.
-export function WindowSetSize(width: number, height: number): Promise<Size>;
+export function WindowSetSize(width: number, height: number): void;
 
 // [WindowGetSize](https://wails.io/docs/reference/runtime/window#windowgetsize)
 // Gets the width and height of the window.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/getkin/kin-openapi v0.131.0
 	github.com/gin-contrib/cors v1.7.2
 	github.com/gin-gonic/gin v1.10.0
+	github.com/go-test/deep v1.0.8
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,6 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
-github.com/paulscherrerinstitute/scicat-cli/v3 v3.0.0-alpha3.0.20250425074246-2b8f0b3497af h1:y8hj2GPAMpjZ4vLqIzcWiVOCeCTsP9seYyPwump4+lM=
-github.com/paulscherrerinstitute/scicat-cli/v3 v3.0.0-alpha3.0.20250425074246-2b8f0b3497af/go.mod h1:0isvmkPG0GVviHOaTk+PrenP6NaPqzHjaKcJo9J+VYE=
 github.com/paulscherrerinstitute/scicat-cli/v3 v3.0.0-alpha5 h1:xo3EMDC54mgF8EpqDloxHIZ/Y5WBftHhiPgkiYbqYyA=
 github.com/paulscherrerinstitute/scicat-cli/v3 v3.0.0-alpha5/go.mod h1:0isvmkPG0GVviHOaTk+PrenP6NaPqzHjaKcJo9J+VYE=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -81,12 +81,13 @@ func (c *ConfigReader) ReadConfig(configFileName string) (Config, error) {
 	c.viperConf.SetDefault("WebServer.Auth.JWT.JwksURL", "https://keycloak.psi.ch/realms/facility/protocol/openid-connect/certs")
 	c.viperConf.SetDefault("WebServer.Auth.JWT.JwksSignatureMethods", []string{"RS256"})
 
-	c.viperConf.SetDefault("WebServer.MetadataExtJobs.ConcurrencyLimit", 100)
+	c.viperConf.SetDefault("WebServer.MetadataExtJobs.ConcurrencyLimit", 10)
 	c.viperConf.SetDefault("WebServer.MetadataExtJobs.QueueSize", 200)
 
 	c.viperConf.SetDefault("WebServer.Other.Port", 8888)
 	c.viperConf.SetDefault("WebServer.Other.LogLevel", "Info")
 	c.viperConf.SetDefault("WebServer.Other.DisableServiceAccountCheck", false)
+	c.viperConf.SetDefault("WebServer.Other.GlobalConcurrencyLimit", 64)
 
 	err := c.viperConf.ReadInConfig()
 	if err == nil {

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -1,13 +1,13 @@
 package core
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/SwissOpenEM/Ingestor/internal/metadataextractor"
 	"github.com/SwissOpenEM/Ingestor/internal/transfertask"
 	"github.com/SwissOpenEM/Ingestor/internal/webserver/wsconfig"
+	"github.com/go-test/deep"
 	"github.com/spf13/viper"
 )
 
@@ -16,7 +16,6 @@ func createExpectedValidConfigS3() transfertask.TransferConfig {
 		Method:           "S3",
 		StorageLocation:  "SomeFacility",
 		ConcurrencyLimit: 10,
-		QueueSize:        1000,
 		S3: transfertask.S3TransferConfig{
 			Endpoint:        "https://endpoint/api/v1",
 			TokenUrl:        "https://keycloak.localhost/realms/facility/protocol/openid-connect/token",
@@ -33,7 +32,6 @@ func createExpectedValidConfigGlobus() transfertask.TransferConfig {
 		Method:           "Globus",
 		StorageLocation:  "SomeFacility",
 		ConcurrencyLimit: 10,
-		QueueSize:        1000,
 		Globus: transfertask.GlobusTransferConfig{
 			ClientID:                "clientid_registered_with_globus",
 			RedirectURL:             "https://auth.globus.org/v2/web/auth-code",
@@ -90,8 +88,9 @@ func createExpectedValidConfig(transferConfig transfertask.TransferConfig) Confi
 			QueueSize:        200,
 		},
 		OtherConf: wsconfig.OtherConf{
-			Port:     8888,
-			LogLevel: "Info",
+			Port:                   8888,
+			LogLevel:               "Info",
+			GlobalConcurrencyLimit: 64,
 		},
 	}
 
@@ -196,8 +195,9 @@ func TestReadConfigS3(t *testing.T) {
 				t.Errorf("ReadConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ReadConfig() = %v, want %v", got, tt.want)
+			diff := deep.Equal(got, tt.want)
+			if diff != nil {
+				t.Errorf("compare failed: %v", diff)
 			}
 		})
 	}
@@ -234,8 +234,9 @@ func TestReadConfigGlobus(t *testing.T) {
 				t.Errorf("ReadConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ReadConfig() = %v, want %v", got, tt.want)
+			diff := deep.Equal(got, tt.want)
+			if diff != nil {
+				t.Errorf("compare failed: %v", diff)
 			}
 		})
 	}

--- a/internal/core/taskqueue.go
+++ b/internal/core/taskqueue.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/SwissOpenEM/Ingestor/internal/globustransfer"
 	task "github.com/SwissOpenEM/Ingestor/internal/transfertask"
 	"github.com/alitto/pond/v2"
 	"github.com/elliotchance/orderedmap/v2"
@@ -19,22 +18,25 @@ import (
 type TaskQueue struct {
 	taskListLock       sync.RWMutex                                          // locking mechanism for uploadIds and datasetUploadTasks
 	datasetUploadTasks *orderedmap.OrderedMap[uuid.UUID, *task.TransferTask] // For storing requests, mapped to the id's above
-	inputChannel       chan *task.TransferTask                               // Requests to upload data are put into this channel
-	taskPool           pond.Pool
+	// inputChannel       chan *task.TransferTask                               // Requests to upload data are put into this channel
+	taskPool pond.Pool
 
-	AppContext  context.Context
+	appContext  context.Context
 	Config      Config
-	Notifier    task.ProgressNotifier
-	ServiceUser *UserCreds
+	notifier    task.ProgressNotifier
+	serviceUser *UserCreds
 }
 
-func (w *TaskQueue) Startup() {
-	w.inputChannel = make(chan *task.TransferTask)
-	w.datasetUploadTasks = orderedmap.NewOrderedMap[uuid.UUID, *task.TransferTask]()
-	w.taskPool = pond.NewPool(w.Config.Transfer.ConcurrencyLimit, pond.WithQueueSize(w.Config.Transfer.QueueSize))
-	err := globustransfer.SetTemplateForDestinationPath(w.Config.Transfer.Globus.DestinationTemplate)
-	if err != nil {
-		panic(fmt.Sprintf("can't set destination path template for globus due to the following reason: %s", err.Error()))
+func NewTaskQueueFromPool(ctx context.Context, config Config, notifier task.ProgressNotifier, serviceUser *UserCreds, pool pond.Pool) *TaskQueue {
+
+	return &TaskQueue{
+		// inputChannel:       make(chan *task.TransferTask),
+		datasetUploadTasks: orderedmap.NewOrderedMap[uuid.UUID, *task.TransferTask](),
+		taskPool:           pool,
+		appContext:         ctx,
+		Config:             config,
+		notifier:           notifier,
+		serviceUser:        serviceUser,
 	}
 }
 
@@ -67,21 +69,20 @@ func (w *TaskQueue) AddTransferTask(datasetId string, fileList []datasetIngestor
 }
 
 func (w *TaskQueue) executeTransferTask(t *task.TransferTask) {
-	task_context, cancel := context.WithCancel(w.AppContext)
-
+	task_context, cancel := context.WithCancel(w.appContext)
 	t.Cancel = cancel
 
 	r := w.TransferDataset(task_context, t)
 	if r.Error != nil {
 		t.Failed(fmt.Sprintf("failed - error: %s", r.Error.Error()))
-		w.Notifier.OnTaskFailed(t.DatasetFolder.Id, r.Error)
+		w.notifier.OnTaskFailed(t.DatasetFolder.Id, r.Error)
 		return
 	}
 
 	// if not cancelled, mark as finished
 	if t.GetDetails().Status != task.Cancelled {
 		t.Finished()
-		w.Notifier.OnTaskCompleted(t.DatasetFolder.Id, r.Elapsed_seconds)
+		w.notifier.OnTaskCompleted(t.DatasetFolder.Id, r.Elapsed_seconds)
 	}
 }
 
@@ -95,7 +96,7 @@ func (w *TaskQueue) CancelTask(id uuid.UUID) {
 	if uploadTask.Cancel != nil {
 		// note: the task is marked as cancelled in advance in order for the task executer to not mark it as finished
 		uploadTask.Cancelled("transfer was cancelled by the user")
-		w.Notifier.OnTaskCanceled(id)
+		w.notifier.OnTaskCanceled(id)
 		uploadTask.Cancel()
 	}
 }
@@ -117,7 +118,7 @@ func (w *TaskQueue) RemoveTask(id uuid.UUID) error {
 	}
 
 	unlockOnce.Do(w.taskListLock.Unlock)
-	w.Notifier.OnTaskRemoved(id)
+	w.notifier.OnTaskRemoved(id)
 	return nil
 }
 
@@ -129,12 +130,12 @@ func (w *TaskQueue) ScheduleTask(id uuid.UUID) error {
 		return fmt.Errorf("task with id '%s' not found", id.String())
 	}
 
-	task_context, cancel := context.WithCancel(w.AppContext)
+	task_context, cancel := context.WithCancel(w.appContext)
 	transferTask.Context = task_context
 	transferTask.Cancel = cancel
 
 	transferTask.Queued()
-	w.Notifier.OnTaskScheduled(transferTask.DatasetFolder.Id)
+	w.notifier.OnTaskScheduled(transferTask.DatasetFolder.Id)
 
 	w.taskPool.Submit(func() { w.executeTransferTask(transferTask) })
 	return nil
@@ -177,6 +178,10 @@ func (w *TaskQueue) GetTaskCount() int {
 	return w.datasetUploadTasks.Len()
 }
 
+func (w *TaskQueue) CreateSubpool(size int) pond.Pool {
+	return w.taskPool.NewSubpool(size)
+}
+
 func (w *TaskQueue) GetTaskFolder(id uuid.UUID) string {
 	w.taskListLock.RLock()
 	defer w.taskListLock.RUnlock()
@@ -189,7 +194,7 @@ func (w *TaskQueue) GetTaskFolder(id uuid.UUID) string {
 
 func (w *TaskQueue) TransferDataset(taskCtx context.Context, it *task.TransferTask) task.Result {
 	start := time.Now()
-	err := TransferDataset(taskCtx, it, w.ServiceUser, w.Config, w.Notifier)
+	err := TransferDataset(taskCtx, it, w.serviceUser, w.Config, w.notifier)
 	end := time.Now()
 	elapsed := end.Sub(start)
 	return task.Result{Elapsed_seconds: int(elapsed.Seconds()), Error: err}
@@ -209,4 +214,8 @@ func (w *TaskQueue) GetTransferMethod() (transferMethod task.TransferMethod) {
 		panic("unknown transfer method")
 	}
 	return transferMethod
+}
+
+func (w *TaskQueue) IsServiceUserSet() bool {
+	return w.serviceUser != nil
 }

--- a/internal/core/taskqueue.go
+++ b/internal/core/taskqueue.go
@@ -18,8 +18,7 @@ import (
 type TaskQueue struct {
 	taskListLock       sync.RWMutex                                          // locking mechanism for uploadIds and datasetUploadTasks
 	datasetUploadTasks *orderedmap.OrderedMap[uuid.UUID, *task.TransferTask] // For storing requests, mapped to the id's above
-	// inputChannel       chan *task.TransferTask                               // Requests to upload data are put into this channel
-	taskPool pond.Pool
+	taskPool           pond.Pool
 
 	appContext  context.Context
 	Config      Config
@@ -30,7 +29,6 @@ type TaskQueue struct {
 func NewTaskQueueFromPool(ctx context.Context, config Config, notifier task.ProgressNotifier, serviceUser *UserCreds, pool pond.Pool) *TaskQueue {
 
 	return &TaskQueue{
-		// inputChannel:       make(chan *task.TransferTask),
 		datasetUploadTasks: orderedmap.NewOrderedMap[uuid.UUID, *task.TransferTask](),
 		taskPool:           pool,
 		appContext:         ctx,

--- a/internal/s3upload/httpuploader.go
+++ b/internal/s3upload/httpuploader.go
@@ -36,7 +36,7 @@ type HttpUploader struct {
 var instance *HttpUploader
 var once sync.Once
 
-func GetHttpUploader(poolSize int) *HttpUploader {
+func InitHttpUploaderWithPool(pool pond.Pool) {
 	once.Do(func() {
 		retryClient := retryablehttp.NewClient()
 		retryClient.RetryMax = 10
@@ -44,8 +44,11 @@ func GetHttpUploader(poolSize int) *HttpUploader {
 		retryClient.Logger = log()
 
 		standardClient := retryClient.StandardClient()
-		instance = &HttpUploader{Pool: pond.NewPool(poolSize), Client: standardClient}
+		instance = &HttpUploader{Pool: pool, Client: standardClient}
 	})
+}
+
+func GetHttpUploader() *HttpUploader {
 	return instance
 }
 
@@ -136,7 +139,7 @@ func uploadFile(ctx context.Context, filePath string, objectName string, options
 	}
 
 	totalSize := fileInfo.Size()
-	httpClient := GetHttpUploader(options.PoolSize)
+	httpClient := GetHttpUploader()
 
 	token, err := tokenSource.Token()
 	if err != nil {

--- a/internal/webserver/api.go
+++ b/internal/webserver/api.go
@@ -22,7 +22,7 @@ var _ StrictServerInterface = (*IngestorWebServerImplemenation)(nil)
 type IngestorWebServerImplemenation struct {
 	version          string
 	taskQueue        *core.TaskQueue
-	metp             *metadatatasks.MetadataExtractionTaskPool
+	metadataExtPool  *metadatatasks.MetadataExtractionTaskPool
 	extractorHandler *metadataextractor.ExtractorHandler
 	oauth2Config     *oauth2.Config
 	globusAuthConf   *oauth2.Config
@@ -41,64 +41,62 @@ type IngestorWebServerImplemenation struct {
 	}
 }
 
-func NewIngestorWebServer(version string, tq *core.TaskQueue, eh *metadataextractor.ExtractorHandler, ws wsconfig.WebServerConfig) (*IngestorWebServerImplemenation, error) {
-	oidcProvider, err := oidc.NewProvider(context.Background(), ws.IssuerURL)
+func NewIngestorWebServer(version string, transferQueue *core.TaskQueue, extractorHandler *metadataextractor.ExtractorHandler, metadataExtPool *metadatatasks.MetadataExtractionTaskPool, serverConf wsconfig.WebServerConfig) (*IngestorWebServerImplemenation, error) {
+	oidcProvider, err := oidc.NewProvider(context.Background(), serverConf.IssuerURL)
 	if err != nil {
 		fmt.Println("Warning: OIDC discovery mechanism failed. Falling back to manual OIDC config")
 		// fallback provider (this could also be replaced with an error)
 		a := &oidc.ProviderConfig{
-			IssuerURL:   ws.IssuerURL,
-			AuthURL:     ws.AuthURL,
-			TokenURL:    ws.TokenURL,
-			UserInfoURL: ws.UserInfoURL,
-			Algorithms:  ws.Algorithms,
+			IssuerURL:   serverConf.IssuerURL,
+			AuthURL:     serverConf.AuthURL,
+			TokenURL:    serverConf.TokenURL,
+			UserInfoURL: serverConf.UserInfoURL,
+			Algorithms:  serverConf.Algorithms,
 		}
 		oidcProvider = a.NewProvider(context.Background())
 	}
-	oidcVerifier := oidcProvider.Verifier(&oidc.Config{ClientID: ws.OAuth2Conf.ClientID})
+	oidcVerifier := oidcProvider.Verifier(&oidc.Config{ClientID: serverConf.OAuth2Conf.ClientID})
 	oauthConf := oauth2.Config{
-		ClientID:     ws.OAuth2Conf.ClientID,
-		ClientSecret: ws.ClientSecret,
+		ClientID:     serverConf.OAuth2Conf.ClientID,
+		ClientSecret: serverConf.ClientSecret,
 		Endpoint:     oidcProvider.Endpoint(),
-		RedirectURL:  ws.RedirectURL,
-		Scopes:       append([]string{oidc.ScopeOpenID}, ws.Scopes...),
+		RedirectURL:  serverConf.RedirectURL,
+		Scopes:       append([]string{oidc.ScopeOpenID}, serverConf.Scopes...),
 	}
 
-	keyfunc, err := initKeyfunc(ws.JWTConf)
+	keyfunc, err := initKeyfunc(serverConf.JWTConf)
 	if err != nil {
 		return nil, err
 	}
 
 	var signMethods []string
-	if ws.UseJWKS {
-		signMethods = ws.JwksSignatureMethods
+	if serverConf.UseJWKS {
+		signMethods = serverConf.JwksSignatureMethods
 	} else {
-		signMethods = []string{ws.JWTConf.KeySignMethod}
+		signMethods = []string{serverConf.JWTConf.KeySignMethod}
 	}
 
-	scopeToRoleMap, err := createScopeToRoleMap(ws.RBACConf)
+	scopeToRoleMap, err := createScopeToRoleMap(serverConf.RBACConf)
 	if err != nil {
 		return nil, err
 	}
 
-	metadataTaskPool := metadatatasks.NewTaskPool(ws.QueueSize, ws.ConcurrencyLimit, eh)
-
 	globusAuthConf := globus.AuthGenerateOauthClientConfig(
 		context.Background(),
-		tq.Config.Transfer.Globus.ClientID,
-		tq.Config.Transfer.Globus.ClientSecret,
-		tq.Config.Transfer.Globus.RedirectURL,
-		tq.Config.Transfer.Globus.Scopes,
+		transferQueue.Config.Transfer.Globus.ClientID,
+		transferQueue.Config.Transfer.Globus.ClientSecret,
+		transferQueue.Config.Transfer.Globus.RedirectURL,
+		transferQueue.Config.Transfer.Globus.Scopes,
 	)
 
-	if tq.ServiceUser == nil && !ws.DisableServiceAccountCheck {
+	if !transferQueue.IsServiceUserSet() && !serverConf.DisableServiceAccountCheck {
 		panic(fmt.Errorf("no service account was set. Set INGESTOR_SERVICE_USER_NAME and INGESTOR_SERVICE_USER_PASSWORD environment variables."))
 	}
 
 	return &IngestorWebServerImplemenation{
 		version:          version,
-		taskQueue:        tq,
-		extractorHandler: eh,
+		taskQueue:        transferQueue,
+		extractorHandler: extractorHandler,
 		oauth2Config:     &oauthConf,
 		globusAuthConf:   &globusAuthConf,
 		oidcProvider:     oidcProvider,
@@ -106,17 +104,17 @@ func NewIngestorWebServer(version string, tq *core.TaskQueue, eh *metadataextrac
 		jwtKeyfunc:       keyfunc,
 		jwtSignMethods:   signMethods,
 		scopeToRoleMap:   scopeToRoleMap,
-		sessionDuration:  ws.SessionDuration,
-		disableAuth:      ws.AuthConf.Disable,
-		pathConfig:       ws.PathsConf,
-		secureCookies:    ws.SecureCookies,
-		metp:             metadataTaskPool,
+		sessionDuration:  serverConf.SessionDuration,
+		disableAuth:      serverConf.AuthConf.Disable,
+		pathConfig:       serverConf.PathsConf,
+		secureCookies:    serverConf.SecureCookies,
+		metadataExtPool:  metadataExtPool,
 		frontend: struct {
 			origin       string
 			redirectPath string
 		}{
-			origin:       ws.FrontendConf.Origin,
-			redirectPath: ws.FrontendConf.RedirectPath,
+			origin:       serverConf.FrontendConf.Origin,
+			redirectPath: serverConf.FrontendConf.RedirectPath,
 		},
 	}, nil
 }

--- a/internal/webserver/dataset_test.go
+++ b/internal/webserver/dataset_test.go
@@ -42,7 +42,7 @@ func TestDatasetControllerBrowseFilesystem_LocationList(t *testing.T) {
 			DisableServiceAccountCheck: true,
 		},
 	}
-	i, err := NewIngestorWebServer("test", &core.TaskQueue{}, nil, wsConf)
+	i, err := NewIngestorWebServer("test", &core.TaskQueue{}, nil, nil, wsConf)
 	if err != nil {
 		t.Errorf("NewIngestorWebServer error: %s", err.Error())
 		return
@@ -134,7 +134,7 @@ func TestDatasetControllerBrowseFilesystem_ExampleListInCollection(t *testing.T)
 			DisableServiceAccountCheck: true,
 		},
 	}
-	i, err := NewIngestorWebServer("test", &core.TaskQueue{}, nil, wsConf)
+	i, err := NewIngestorWebServer("test", &core.TaskQueue{}, nil, nil, wsConf)
 	if err != nil {
 		t.Errorf("NewIngestorWebServer error: %s", err.Error())
 		return

--- a/internal/webserver/extractor.go
+++ b/internal/webserver/extractor.go
@@ -6,7 +6,7 @@ import (
 
 func (i *IngestorWebServerImplemenation) ExtractorControllerGetExtractorMethods(ctx context.Context, request ExtractorControllerGetExtractorMethodsRequestObject) (ExtractorControllerGetExtractorMethodsResponseObject, error) {
 	// get methods
-	methods := i.extractorHandler.AvailableMethods()
+	methods := i.metadataExtPool.GetHandler().AvailableMethods()
 	total := len(methods)
 
 	// get indices

--- a/internal/webserver/metadata.go
+++ b/internal/webserver/metadata.go
@@ -152,7 +152,7 @@ func (i *IngestorWebServerImplemenation) ExtractMetadata(ctx context.Context, re
 	}
 
 	// start streaming the extraction process
-	return ResponseWriter{ctx: ctx, metadataTaskPool: i.metp, req: request, collectionLocation: colPath}, nil
+	return ResponseWriter{ctx: ctx, metadataTaskPool: i.metadataExtPool, req: request, collectionLocation: colPath}, nil
 }
 
 type progressDto struct {

--- a/internal/webserver/metadatatasks/taskpool.go
+++ b/internal/webserver/metadatatasks/taskpool.go
@@ -34,13 +34,16 @@ func (p *MetadataExtractionTaskPool) NewTask(ctx context.Context, datasetPath st
 	return &progress, nil
 }
 
-func NewTaskPool(queueSize int, maxConcurrency int, handler *metadataextractor.ExtractorHandler) *MetadataExtractionTaskPool {
-	pondPool := pond.NewPool(int(maxConcurrency), pond.WithQueueSize(int(queueSize)))
-	pool := MetadataExtractionTaskPool{
-		pool:              pondPool,
+func (p *MetadataExtractionTaskPool) GetHandler() *metadataextractor.ExtractorHandler {
+	return p.extractionHandler
+}
+
+func NewTaskPoolFromPool(maxConcurrency int, queueSize int, handler *metadataextractor.ExtractorHandler, pool *pond.Pool) *MetadataExtractionTaskPool {
+	subpool := (*pool).NewSubpool(int(maxConcurrency), pond.WithQueueSize(int(queueSize)))
+	taskPool := MetadataExtractionTaskPool{
+		pool:              subpool,
 		waitGroup:         sync.WaitGroup{},
 		extractionHandler: handler,
 	}
-
-	return &pool
+	return &taskPool
 }

--- a/internal/webserver/wsconfig/config.go
+++ b/internal/webserver/wsconfig/config.go
@@ -68,7 +68,8 @@ type OtherConf struct {
 	DisableServiceAccountCheck bool
 	// If true, all cookies will be set with Secure=true
 	// If false, Secure will only be set if TLS is detected
-	SecureCookies bool `bool:"SecureCookies"`
+	SecureCookies          bool `bool:"SecureCookies"`
+	GlobalConcurrencyLimit int  `int:"GlobalConcurrencyLimit" validate:"min=1"`
 }
 
 type WebServerConfig struct {

--- a/test/testdata/valid_config.yaml
+++ b/test/testdata/valid_config.yaml
@@ -14,16 +14,15 @@ Transfer:
   #     - "urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/[collection_id1]/data_access]"
   S3:
     Endpoint: http://localhost:8000
-Misc:
-  ConcurrencyLimit: 2
-  Port: 8888
-  LogLevel: Info
+  ConcurrencyLimit: 4
+
 MetadataExtractors:
   InstallationPath: ./parentPathToAllExtractors/
   DownloadMissingExtractors: false
   DownloadSchemas: false
   SchemasLocation: ./ExtractorSchemas
   Timeout: 4m
+  ConcurrencyLimit: 2
   Extractors:
   - Name: LS
     GithubOrg: SwissOpenEM
@@ -71,3 +70,7 @@ Webserver:
       AdminRole: "FACILITY-ingestor-admin"
       CreateModifyTasksRole: "FACILITY-ingestor-write"
       ViewTasksRole: "FACILITY-ingestor-read"
+
+  Other:
+    Port: 8888
+    LogLevel: Info

--- a/test/testdata/valid_config_globus.yaml
+++ b/test/testdata/valid_config_globus.yaml
@@ -2,7 +2,6 @@ Scicat:
   Host: http://scicat:8080/api/v3
 Transfer:
   ConcurrencyLimit: 10
-  QueueSize: 1000
   Method: Globus
   StorageLocation: "SomeFacility"
   Globus:
@@ -92,3 +91,4 @@ WebServer:
   Other:
     Port: 8888
     LogLevel: "Info"
+    GlobalConcurrencyLimit: 64

--- a/test/testdata/valid_config_s3.yaml
+++ b/test/testdata/valid_config_s3.yaml
@@ -4,7 +4,6 @@ Transfer:
   Method: S3
   StorageLocation: "SomeFacility"
   ConcurrencyLimit: 10
-  QueueSize: 1000
   S3:
     Endpoint: https://endpoint/api/v1
     TokenUrl: https://keycloak.localhost/realms/facility/protocol/openid-connect/token


### PR DESCRIPTION
Ensure that the number of go routine is limited and that in case of upload, the extractor tasks are not blocked. With different pools for the transfer and the extractor, this should be achieved.