### PR TITLE
Ubuntu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ COPY ./internal ./internal
 
 ARG VERSION=1.2.3
 # Build
-RUN CGO_ENABLED=1 GOOS=linux go generate ./internal/webserver
-RUN CGO_ENABLED=1 GOOS=linux go build -C ./cmd/openem-ingestor-service/ -v -o /app/ingestor  -ldflags="-s -w  -X 'main.version=${VERSION}'"
+RUN CGO_ENABLED=0 GOOS=linux go generate ./internal/webserver
+RUN CGO_ENABLED=0 GOOS=linux go build -C ./cmd/openem-ingestor-service/ -v -o /app/ingestor  -ldflags="-s -w  -X 'main.version=${VERSION}'"
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
Make docker image compatible with MS extractor. 
* build on ubuntu 24 instead of alpine
* add ca certificates package to it