### PR TITLE
fix(s3): only pass files and not folders to s3 transfer task

### DIFF
--- a/internal/webserver/dataset.go
+++ b/internal/webserver/dataset.go
@@ -334,7 +334,15 @@ func (i *IngestorWebServerImplemenation) addS3TransferTask(ctx context.Context, 
 	transferObjects["refreshToken"] = refreshToken
 	transferObjects["expires_in"] = expiresIn
 
-	err = i.taskQueue.AddTransferTask(datasetID, fileList, taskID, folderPath, ownerUser, ownerGroup, contactEmail, autoArchive, transferObjects)
+	filteredFileList := []datasetIngestor.Datafile{}
+	for _, f := range fileList {
+		info, _ := os.Stat(path.Join(folderPath, f.Path))
+		if info.IsDir() {
+			continue
+		}
+		filteredFileList = append(filteredFileList, f)
+	}
+	err = i.taskQueue.AddTransferTask(datasetID, filteredFileList, taskID, folderPath, ownerUser, ownerGroup, contactEmail, autoArchive, transferObjects)
 	if err != nil {
 		return uuid.UUID{}, err
 	}


### PR DESCRIPTION
this fixes the expected number of files to be transfered in the progress. 

<img width="797" height="453" alt="image" src="https://github.com/user-attachments/assets/92a95e97-0910-4f78-960a-017fa33160af" />

This should read 10/10 Files